### PR TITLE
Fix: Remove mouse icon from landing page (Issue #4)

### DIFF
--- a/phialo-design/src/components/sections/Hero.astro
+++ b/phialo-design/src/components/sections/Hero.astro
@@ -93,12 +93,6 @@ const t = isEnglish ? content.en : content.de;
       <QualityBadge type="custom" />
     </div>
     
-    <!-- Scroll indicator -->
-    <div class="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
-      <div class="w-6 h-10 border-2 border-theme-border rounded-full flex justify-center">
-        <div class="w-1 h-3 bg-theme-border rounded-full mt-2 animate-pulse"></div>
-      </div>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Removed the animated scroll indicator (mouse icon) from the Hero section
- No hovering logo was found in the codebase to remove
- Simplifies the landing page design as requested

## Changes Made
- Deleted lines 96-101 in `src/components/sections/Hero.astro` containing the scroll indicator element
- The element consisted of a bouncing mouse-shaped icon with a pulsing dot inside

## Test Plan
- [x] Build passes without errors (`npm run build`)
- [ ] Visually verify the landing page no longer shows the mouse icon at the bottom of the hero section
- [ ] Confirm no layout issues from removing the element

Fixes #4