### PR TITLE
Remove Weglot integration and clean up related code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is **Phialo Design**, a luxury jewelry portfolio website built with Astro 5.9.3 using Islands Architecture. The site features German/English multilingual support via Weglot API and is deployed on Cloudflare Pages at `phialo.de`.
+This is **Phialo Design**, a luxury jewelry portfolio website built with Astro 5.9.3 using Islands Architecture. The site features German/English multilingual support and is deployed on Cloudflare Pages at `phialo.de`.
 
 ## Common Development Commands
 
@@ -66,11 +66,11 @@ phialo-design/src/
 
 ## Multilingual System
 
-The site uses **Weglot API** for German/English translation:
-- LanguageSelector component handles language switching with persistence
-- Language state persists during page navigation
-- Weglot integration is configured in the layout templates
-- Never implement Google Translate or other translation services - use Weglot only
+The site uses a custom URL-based multilingual system for German/English support:
+- LanguageSelector component handles language switching with localStorage persistence
+- German is the default language (served at root `/`)
+- English content is served under `/en/` prefix
+- Language preference persists across page navigation
 
 ### Important Notes on React Hydration
 - Portfolio and other React components use URL-based language detection
@@ -105,7 +105,7 @@ Tailwind configuration includes:
 - Deployed on **Cloudflare Pages** with automatic builds from git
 - Also possible to deploy via instructions from `DEPLOY.md` to get more debug data via web browsing
 - Security headers configured in `public/_headers`
-- CSP allows YouTube embeds and Weglot integration
+- CSP allows YouTube embeds
 - Both production and preview environments available
 
 ## Key Files to Understand
@@ -113,7 +113,7 @@ Tailwind configuration includes:
 - `astro.config.mjs`: Core Astro configuration with React/Tailwind integration
 - `tailwind.config.mjs`: Complete design system definition
 - `src/content/config.ts`: Content collections schema
-- `src/components/layout/LanguageSelector.tsx`: Critical for multilingual functionality
+- `src/components/layout/LanguageSelector.astro`: Handles language switching
 - `public/_headers`: Security and caching configuration
 
 ## AI Development Guidelines
@@ -127,6 +127,8 @@ Tailwind configuration includes:
 ## GitHub Workflow
 
 - Always solve issues from GitHub in branches and make PRs
+- Work with feature branches preferably linking them to GitHub issues using the `gh` command
+- Leave clean git status results after work by pushing open files in their respective branches
 
 ## Browser Automation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ npm run test
 - **[TypeScript](https://www.typescriptlang.org/)** - Type safety
 - **[Tailwind CSS](https://tailwindcss.com/)** - Styling with custom design system
 - **[Cloudflare Pages](https://pages.cloudflare.com/)** - Hosting and edge functions
-- **[Weglot](https://www.weglot.com/)** - Multilingual support (DE/EN)
 
 ## 📁 Project Structure
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -266,7 +266,7 @@ phialoastro/
 
 3. **Content Security**
    - Worker implements security headers
-   - CSP configured for Weglot, YouTube, and Web3Forms
+   - CSP configured for YouTube and Web3Forms
    - X-Frame-Options prevents clickjacking
 
 4. **Environment Variables**

--- a/phialo-design/ISSUE-MIGRATE-TO-WORKERS.md
+++ b/phialo-design/ISSUE-MIGRATE-TO-WORKERS.md
@@ -31,7 +31,7 @@ Currently, Phialo Design is deployed using Cloudflare Pages, which provides exce
 **Architecture:**
 - Static site built with Astro 5.9.3
 - React components with selective hydration (Islands Architecture)
-- Multilingual support via Weglot API
+- Multilingual support via URL-based routing
 - Deployed via `wrangler pages deploy`
 
 **Key Files:**
@@ -118,7 +118,7 @@ phialo-design/
    - [ ] Handle 404/error pages
 
 5. **Multilingual Support**
-   - [ ] Ensure Weglot integration works
+   - [ ] Ensure language switching works
    - [ ] Handle language detection and routing
    - [ ] Test cookie persistence
 
@@ -271,7 +271,7 @@ npm run worker:dev
 
 ### Functional Requirements
 - [ ] All pages load correctly in both languages
-- [ ] Weglot integration functions properly
+- [ ] Language switching functions properly
 - [ ] Security headers present on all responses
 - [ ] Preview deployments work for PRs
 - [ ] Local development experience maintained

--- a/workers/src/handlers/headers.ts
+++ b/workers/src/handlers/headers.ts
@@ -9,12 +9,12 @@ export function applyHeaders(response: Response, request: Request): Response {
   
   const csp = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.weglot.com https://www.youtube.com https://www.youtube-nocookie.com",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.youtube.com https://www.youtube-nocookie.com",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https: blob:",
     "media-src 'self' https:",
-    "connect-src 'self' https://api.weglot.com https://cdn.weglot.com wss://api.weglot.com",
+    "connect-src 'self'",
     "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
     "object-src 'none'",
     "base-uri 'self'",

--- a/workers/test/headers.test.ts
+++ b/workers/test/headers.test.ts
@@ -31,7 +31,7 @@ describe('Headers Handler', () => {
     const csp = result.headers.get('Content-Security-Policy');
 
     expect(csp).toContain("default-src 'self'");
-    expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.weglot.com");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain('upgrade-insecure-requests');


### PR DESCRIPTION
## Summary
- Removed all references to Weglot API from the codebase
- Updated documentation to reflect URL-based multilingual routing
- Cleaned up CSP headers and tests

## Changes Made

### Documentation Updates
- **CLAUDE.md**: Removed Weglot API mention and updated multilingual system documentation
- **README.md**: Removed Weglot from tech stack
- **docs/DEPLOYMENT_GUIDE.md**: Removed Weglot from security considerations
- **phialo-design/ISSUE-MIGRATE-TO-WORKERS.md**: Updated migration checklist

### Code Changes
- **workers/src/handlers/headers.ts**: Removed Weglot domains from CSP headers
  - Removed `https://cdn.weglot.com` from script-src
  - Removed `https://api.weglot.com`, `https://cdn.weglot.com`, and `wss://api.weglot.com` from connect-src
- **workers/test/headers.test.ts**: Updated test expectations to match new CSP

## Test Results
- ✅ All worker tests passing
- ✅ Unit tests passing
- ✅ No remaining Weglot references in codebase

## Checklist
- [x] All Weglot references removed from documentation
- [x] CSP headers updated to remove Weglot domains
- [x] Tests updated and passing
- [x] Language switching functionality remains intact

Fixes #50