### PR TITLE
chore: update .gitignore with comprehensive file exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,23 @@ temp/
 
 # Test results
 phialo-design/test-results/
+*.zip
+*.tar
+*.tar.gz
+*.tgz
+*.rar
+*.7z
+*.dmg
+*.iso
+*.jar
+*.war
+*.exe
+*.dll
+*.so
+*.dylib
+*.bin
+*.dat
+*.bak
+*.backup
+*.old
+*.orig


### PR DESCRIPTION
## Summary
Updates .gitignore to exclude various binary, archive, and temporary file types.

## Changes
- Added exclusions for archive formats: zip, tar, gz, rar, 7z, etc.
- Added exclusions for binary files: exe, dll, so, dylib, bin
- Added exclusions for backup files: bak, backup, old, orig
- Added exclusions for data files: dat

This prevents accidentally committing these file types to the repository.