### PR TITLE
fix: remove profile.png from homepage hero section

### DIFF
--- a/phialo-design/public/images/profile.png
+++ b/phialo-design/public/images/profile.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40467cd6eaa7274ca4741ef7a88d0f216cc9755ff1171654ec65a3adfed05880
-size 27746

--- a/phialo-design/src/features/home/components/HeroSection.astro
+++ b/phialo-design/src/features/home/components/HeroSection.astro
@@ -39,13 +39,7 @@ const t = isEnglish ? content.en : content.de;
   <!-- Background -->
   <div class="hero-bg absolute inset-0">
     <!-- Gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-theme-background/95 via-theme-background/80 to-theme-background/90 z-10"></div>      <!-- Profile image from old site -->
-    <div 
-      class="hero-jewelry absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 h-96 opacity-30"
-      data-parallax="0.3"
-    >
-      <img src="/images/profile.png" alt="Phialo Design Profile" class="w-full h-full object-contain" />
-    </div>
+    <div class="absolute inset-0 bg-gradient-to-br from-theme-background/95 via-theme-background/80 to-theme-background/90 z-10"></div>
     
     <!-- Subtle pattern overlay -->
     <div class="absolute inset-0 opacity-5" style="background-image: radial-gradient(circle at 1px 1px, rgba(10,25,47,0.15) 1px, transparent 0); background-size: 60px 60px;"></div>

--- a/phialo-design/src/shared/components/ui/LazyImage.tsx
+++ b/phialo-design/src/shared/components/ui/LazyImage.tsx
@@ -13,7 +13,7 @@ export default function LazyImage({
   src, 
   alt, 
   className = '', 
-  placeholder = '/images/profile.png', // Use existing profile image as fallback
+  placeholder = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="400" height="400"%3E%3Crect width="400" height="400" fill="%23f0f0f0"/%3E%3C/svg%3E', // Simple gray placeholder
   aspectRatio = '1/1',
   objectFit = 'cover'
 }: LazyImageProps) {


### PR DESCRIPTION
## Summary
- Remove centered profile image from HeroSection.astro
- Update LazyImage.tsx to use SVG placeholder instead of profile.png
- Delete unused profile.png file from public/images

## Changes Made
1. Removed the profile image div (lines 43-48) from `HeroSection.astro`
2. Updated `LazyImage.tsx` to use a simple gray SVG placeholder instead of `/images/profile.png`
3. Deleted the unused `profile.png` file from `public/images/`

## Test Results
- ✅ Hero section displays correctly without profile image
- ✅ LazyImage component works with new SVG placeholder
- ✅ No console errors
- ✅ Visual hierarchy maintained with cleaner look
- ✅ Development server tested at http://localhost:4321/

Closes #56