### PR TITLE
Fix: Add 20px left margin to navbar PHIALO text

### DIFF
--- a/phialo-design/src/shared/navigation/Header.astro
+++ b/phialo-design/src/shared/navigation/Header.astro
@@ -28,7 +28,7 @@ const logoAriaLabel = isEnglish ? 'Phialo Design Homepage' : 'Phialo Design Star
       <!-- Logo -->
       <a 
         href={logoHref}
-        class="font-display text-2xl font-medium text-theme-text-primary hover:text-theme-accent transition-colors"
+        class="ml-5 font-display text-2xl font-medium text-theme-text-primary hover:text-theme-accent transition-colors"
         aria-label={logoAriaLabel}
       >
         PHIALO


### PR DESCRIPTION
## Summary
- Added 20px left margin to the PHIALO text in the navbar header to prevent it from touching the left edge of the screen
- Applied the `ml-5` Tailwind CSS class (which equals 20px) to the logo link

## Changes
- Modified `src/shared/navigation/Header.astro` to add the `ml-5` class to the PHIALO logo link

## Testing
- ✅ Verified margin is applied on desktop viewports
- ✅ Verified margin is applied on mobile viewports  
- ✅ Tested on both German (/) and English (/en/) versions
- ✅ All unit tests pass (`npm run test:run`)
- ✅ Build completes successfully (`npm run build`)

## Screenshots
The PHIALO text now has proper spacing from the left edge across all screen sizes.

Fixes #97