### PR TITLE
feat: implement ephemeral preview environments with automatic cleanup

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,43 @@
+name: Cleanup Ephemeral Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Delete ephemeral worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          WORKER_NAME="phialo-pr-${{ github.event.pull_request.number }}"
+          
+          # Delete the worker
+          npx wrangler delete "$WORKER_NAME" --force || true
+      
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = context.issue.number;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              body: '## 🧹 Preview Cleaned Up\n\nThe ephemeral preview environment for this PR has been deleted.'
+            });

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    environment: cloudflare
     permissions:
       pull-requests: write
       contents: read

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -76,7 +76,31 @@ jobs:
           script: |
             const preview_url = '${{ steps.deploy.outputs.preview_url }}';
             const pr_number = context.issue.number;
-            const pr_author = context.payload.pull_request.user.login;
+            
+            // Get the PR details to find linked issues
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number
+            });
+            
+            // Extract issue number from PR body or title
+            const issueMatch = pr.body?.match(/#(\d+)/) || pr.title?.match(/#(\d+)/);
+            let issueOwner = null;
+            
+            if (issueMatch) {
+              const issueNumber = issueMatch[1];
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(issueNumber)
+                });
+                issueOwner = issue.user.login;
+              } catch (e) {
+                console.log(`Could not fetch issue #${issueNumber}: ${e.message}`);
+              }
+            }
             
             // Find and update existing comment or create new one
             const { data: comments } = await github.rest.issues.listComments({
@@ -90,9 +114,11 @@ jobs:
               comment.body.includes('Preview Deployment')
             );
             
+            const mentionLine = issueOwner ? `@${issueOwner} Your preview is ready at: ${preview_url}` : `Your preview is ready at: ${preview_url}`;
+            
             const body = `## 🚀 Preview Deployment
             
-            @${pr_author} Your preview is ready at: ${preview_url}
+            ${mentionLine}
             
             **Environment Details:**
             - Worker: \`phialo-pr-${pr_number}\`

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -52,7 +52,6 @@ jobs:
           npx wrangler deploy \
             --name "$WORKER_NAME" \
             --compatibility-date "2024-01-01" \
-            --no-bundle \
             --var ENVIRONMENT:preview \
             --var PR_NUMBER:${{ github.event.pull_request.number }}
           

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -76,6 +76,7 @@ jobs:
           script: |
             const preview_url = '${{ steps.deploy.outputs.preview_url }}';
             const pr_number = context.issue.number;
+            const pr_author = context.payload.pull_request.user.login;
             
             // Find and update existing comment or create new one
             const { data: comments } = await github.rest.issues.listComments({
@@ -91,7 +92,7 @@ jobs:
             
             const body = `## 🚀 Preview Deployment
             
-            Your preview is ready at: ${preview_url}
+            @${pr_author} Your preview is ready at: ${preview_url}
             
             **Environment Details:**
             - Worker: \`phialo-pr-${pr_number}\`

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -1,0 +1,117 @@
+name: Ephemeral Preview Deployment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'workers/**'
+      - 'phialo-design/**'
+      - '.github/workflows/ephemeral-preview.yml'
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: |
+          npm ci --prefix phialo-design
+          npm ci --prefix workers
+      
+      - name: Build Astro site
+        env:
+          ENVIRONMENT: preview
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cd phialo-design
+          npm run build
+      
+      - name: Deploy to ephemeral environment
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd workers
+          # Create unique worker name
+          WORKER_NAME="phialo-pr-${{ github.event.pull_request.number }}"
+          
+          # Deploy with dynamic worker name
+          npx wrangler deploy \
+            --name "$WORKER_NAME" \
+            --compatibility-date "2024-01-01" \
+            --no-bundle \
+            --var ENVIRONMENT:preview \
+            --var PR_NUMBER:${{ github.event.pull_request.number }}
+          
+          # Get the actual deployed URL from wrangler output
+          # The URL will be in format: https://phialo-pr-123.meise.workers.dev
+          PREVIEW_URL=$(npx wrangler deployments list --name "$WORKER_NAME" --json | jq -r '.[0].url // empty')
+          
+          # Fallback if the above doesn't work
+          if [ -z "$PREVIEW_URL" ]; then
+            # Get account subdomain from Cloudflare API
+            SUBDOMAIN=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID" \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              -H "Content-Type: application/json" | jq -r '.result.name' | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
+            PREVIEW_URL="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+          fi
+          
+          echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+      
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const preview_url = '${{ steps.deploy.outputs.preview_url }}';
+            const pr_number = context.issue.number;
+            
+            // Find and update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Preview Deployment')
+            );
+            
+            const body = `## 🚀 Preview Deployment
+            
+            Your preview is ready at: ${preview_url}
+            
+            **Environment Details:**
+            - Worker: \`phialo-pr-${pr_number}\`
+            - Branch: \`${context.payload.pull_request.head.ref}\`
+            - Commit: \`${context.sha.substring(0, 7)}\`
+            
+            This preview will be automatically deleted when the PR is closed or merged.`;
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body
+              });
+            }

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -26,8 +26,8 @@ jobs:
       
       - name: Install dependencies
         run: |
-          npm ci --prefix phialo-design
-          npm ci --prefix workers
+          npm install --prefix phialo-design
+          npm install --prefix workers
       
       - name: Build Astro site
         env:

--- a/.github/workflows/ephemeral-preview.yml
+++ b/.github/workflows/ephemeral-preview.yml
@@ -48,24 +48,31 @@ jobs:
           # Create unique worker name
           WORKER_NAME="phialo-pr-${{ github.event.pull_request.number }}"
           
-          # Deploy with dynamic worker name
-          npx wrangler deploy \
+          # Deploy with dynamic worker name and capture output
+          DEPLOY_OUTPUT=$(npx wrangler deploy \
             --name "$WORKER_NAME" \
             --compatibility-date "2024-01-01" \
             --var ENVIRONMENT:preview \
-            --var PR_NUMBER:${{ github.event.pull_request.number }}
+            --var PR_NUMBER:${{ github.event.pull_request.number }} 2>&1)
           
-          # Get the actual deployed URL from wrangler output
-          # The URL will be in format: https://phialo-pr-123.meise.workers.dev
-          PREVIEW_URL=$(npx wrangler deployments list --name "$WORKER_NAME" --json | jq -r '.[0].url // empty')
+          echo "Deploy output:"
+          echo "$DEPLOY_OUTPUT"
           
-          # Fallback if the above doesn't work
+          # Extract the URL from deployment output
+          # Wrangler outputs: "Published phialo-pr-106 (version = ...) https://phialo-pr-106.subdomain.workers.dev"
+          PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -oE 'https://[^ ]+\.workers\.dev' | tail -1)
+          
+          # If we couldn't extract the URL, try another method
           if [ -z "$PREVIEW_URL" ]; then
-            # Get account subdomain from Cloudflare API
-            SUBDOMAIN=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID" \
-              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-              -H "Content-Type: application/json" | jq -r '.result.name' | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
-            PREVIEW_URL="https://${WORKER_NAME}.${SUBDOMAIN}.workers.dev"
+            echo "Failed to extract URL from deployment output, trying wrangler deployments list"
+            PREVIEW_URL=$(npx wrangler deployments list --name "$WORKER_NAME" --json 2>/dev/null | jq -r '.[0].url // empty' || echo "")
+          fi
+          
+          # Final fallback - construct URL using known pattern
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "Still no URL, using fallback pattern"
+            # For this account, the subdomain appears to be a complex string, so let's use a known pattern
+            PREVIEW_URL="https://${WORKER_NAME}.meise.workers.dev"
           fi
           
           echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/worker-preview.yml
+++ b/.github/workflows/worker-preview.yml
@@ -1,13 +1,19 @@
 ---
-name: Deploy Worker Preview
+name: Deploy Preview from Master
 
 'on':
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
     paths:
       - 'workers/**'
       - 'phialo-design/**'
-      - '.github/workflows/worker-preview.yml'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy to preview'
+        required: false
+        default: 'master'
 
 jobs:
   deploy-preview:
@@ -20,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || 'master' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -82,8 +90,8 @@ jobs:
             echo "- Find the Account ID in the right sidebar"
             exit 1
           fi
-          # Get the branch name from the PR
-          BRANCH_NAME="${{ github.head_ref }}"
+          # Get the branch name
+          BRANCH_NAME="${{ github.event.inputs.branch || 'master' }}"
 
           echo "Starting deployment..."
           # Deploy to preview environment and capture output
@@ -147,81 +155,16 @@ jobs:
           echo "::error::Preview deployment returned HTTP $HTTP_CODE after $MAX_RETRIES attempts"
           exit 1
 
-      - name: Comment on PR
+      - name: Create deployment status
         uses: actions/github-script@v7
         with:
           script: |
             const preview_url = '${{ steps.deploy.outputs.preview_url }}';
             const branch_name = '${{ steps.deploy.outputs.branch_name }}';
-            const pr_number = context.issue.number;
             const sha = context.sha.substring(0, 7);
 
-            // Find existing comment
-            let botComment = null;
-            try {
-              const comments = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr_number,
-              });
-
-              botComment = comments.data.find(comment =>
-                comment.user && comment.user.type === 'Bot' &&
-                comment.body &&
-                comment.body.includes('Cloudflare Workers Preview')
-              );
-            } catch (error) {
-              console.log('Could not fetch existing comments:', error.message);
-            }
-
-            const body = `### 🚀 Cloudflare Workers Preview Deployed!
-
-            <table>
-            <tr>
-            <td><strong>🔗 Preview URL</strong></td>
-            <td><a href="${preview_url}">${preview_url}</a></td>
-            </tr>
-            <tr>
-            <td><strong>🌿 Branch</strong></td>
-            <td><code>${branch_name}</code></td>
-            </tr>
-            <tr>
-            <td><strong>📝 Commit</strong></td>
-            <td><code>${sha}</code></td>
-            </tr>
-            <tr>
-            <td><strong>🕐 Deployed</strong></td>
-            <td>${new Date().toUTCString()}</td>
-            </tr>
-            </table>
-
-            ---
-
-            <details>
-            <summary>ℹ️ <strong>Preview Information</strong></summary>
-
-            - 🔄 This preview will be automatically updated on each commit
-            - 🌍 The preview runs on Cloudflare's global edge network
-            - 🔒 Security headers and CSP policies are active
-            - 💾 Edge caching is enabled for optimal performance
-            - 🐛 Check browser DevTools for any console errors
-
-            </details>`;
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr_number,
-                body: body
-              });
-            }
+            // Create a deployment status
+            console.log(`✅ Preview deployed to ${preview_url}`);
+            console.log(`   Branch: ${branch_name}`);
+            console.log(`   Commit: ${sha}`);
+            console.log(`   Time: ${new Date().toUTCString()}`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,12 +333,40 @@ npm list --depth=0 | grep -E "^├|^└" | sort -k2 -hr
 
 ## Deployment
 
-- Deployed on **Cloudflare Workers** with automatic builds from git
-- Also possible to deploy via instructions from [DEPLOY.md](./docs/how-to/DEPLOY.md) to get more debug data via web browsing
+### Deployment Environments
+
+#### Production (`phialo-design`)
+- **URL**: https://phialo.de (custom domain)
+- **Deployment**: Manual via GitHub UI or CLI
+- **Branch**: Tagged releases only
+- **Note**: Requires zone permissions for custom domain
+
+#### Preview (`phialo-design-preview`) 
+- **URL**: https://phialo-design-preview.meise.workers.dev
+- **Deployment**: Automatic on merge to master
+- **Purpose**: Latest master branch preview
+- **Manual Deploy**: Available via GitHub Actions UI
+
+#### Ephemeral PR Previews (`phialo-pr-{number}`)
+- **URL**: https://phialo-pr-{number}.meise.workers.dev
+- **Deployment**: Automatic on PR creation/update
+- **Cleanup**: Automatic on PR close/merge
+- **Purpose**: Isolated testing for each PR
+
+### Cloudflare API Requirements
+
+For workers.dev deployments (preview & PR environments):
+- Account: Workers Scripts:Edit, Workers KV Storage:Edit
+
+For custom domain deployment (production only):
+- Account: Workers Scripts:Edit, Workers KV Storage:Edit
+- Zone (phialo.de): Workers Routes:Edit, Zone:Read
+
+### Technical Details
 - Security headers configured in Workers script
 - CSP allows YouTube embeds
-- Both production and preview environments available
 - Workers handle static asset serving and dynamic routing
+- Also possible to deploy via instructions from [DEPLOY.md](./docs/how-to/DEPLOY.md) to get more debug data via web browsing
 
 ## Key Files to Understand
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ npm run test:e2e
 
 - **Production**: [phialo.de](https://phialo.de) - Custom domain
 - **Master Preview**: [phialo-design-preview.meise.workers.dev](https://phialo-design-preview.meise.workers.dev) - Latest master branch
-- **PR Previews**: Coming soon - Ephemeral environments per PR (see [#99](https://github.com/barde/phialoastro/issues/99))
+- **PR Previews**: `https://phialo-pr-{number}.meise.workers.dev` - Ephemeral per PR
 
 The site uses automatic deployments:
+- PRs get temporary preview environments
 - Master branch deploys to preview environment
 - Production deployments are manual
 


### PR DESCRIPTION
## Summary
- Implements ephemeral preview environments that create unique preview URLs for each PR
- Adds automatic cleanup when PRs are closed or merged
- Converts existing preview workflow to post-merge deployment from master

## Implementation Details

### New Workflows
1. **Ephemeral Preview Deployment** (`.github/workflows/ephemeral-preview.yml`)
   - Triggers on PR open/sync/reopen
   - Creates unique worker: `phialo-pr-{number}`
   - Deploys to: `https://phialo-pr-{number}.meise.workers.dev`
   - Comments on PR with preview URL

2. **Cleanup Preview** (`.github/workflows/cleanup-preview.yml`)
   - Triggers on PR close
   - Deletes the ephemeral worker
   - Comments on PR to confirm cleanup

### Updated Workflows
3. **Worker Preview** (`.github/workflows/worker-preview.yml`)
   - Now triggers on push to master instead of PRs
   - Maintains `phialo-design-preview` as post-merge environment
   - Supports manual deployment via workflow_dispatch

### Documentation Updates
- Updated CLAUDE.md with deployment environment details
- Updated README.md with new preview URL pattern
- Added Cloudflare API permission requirements

## Benefits
- **Isolation**: Each PR gets its own preview environment
- **Resource Efficiency**: Automatic cleanup prevents accumulation of unused workers
- **Continuous Staging**: Preview environment always reflects latest master
- **No Custom DNS**: Uses Cloudflare's provided workers.dev domains
- **Simpler Permissions**: No zone permissions required for preview deployments

## Testing Plan
- [ ] Create test PR to verify ephemeral preview deployment
- [ ] Verify preview URL is accessible
- [ ] Close PR and verify cleanup works
- [ ] Push to master and verify preview deployment updates

Closes #99