### PR TITLE
fix: add cloudflare environment to cleanup-preview workflow

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    environment: cloudflare
     permissions:
       pull-requests: write
     


### PR DESCRIPTION
## Summary
- Added `environment: cloudflare` to the cleanup-preview.yml workflow
- This fixes the "CLOUDFLARE_API_TOKEN environment variable not set" error
- Aligns with other workflows that use Cloudflare secrets

## Problem
The cleanup-preview workflow was failing because it couldn't access the Cloudflare API secrets. The secrets are stored in the `cloudflare` environment, but the workflow wasn't configured to use that environment.

## Solution
Added the `environment: cloudflare` configuration to match other workflows like worker-preview.yml and ephemeral-preview.yml.

## Test plan
- [ ] Verify the workflow runs successfully when a PR is closed
- [ ] Check that the ephemeral worker is actually deleted
- [ ] Confirm the cleanup comment is posted to the PR