### PR TITLE
fix: add --name flag to wrangler delete command

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -27,7 +27,7 @@ jobs:
           WORKER_NAME="phialo-pr-${{ github.event.pull_request.number }}"
           
           # Delete the worker
-          npx wrangler delete "$WORKER_NAME" --force || true
+          npx wrangler delete --name "$WORKER_NAME" --force || true
       
       - name: Comment on PR
         if: always()


### PR DESCRIPTION
## Summary
- Added `--name` flag to the `wrangler delete` command in cleanup-preview.yml
- Fixes the "A worker name must be defined" error

## Problem
After fixing the environment configuration in PR #116, the cleanup workflow still failed because the `wrangler delete` command was missing the `--name` flag.

## Solution
Updated the command from:
```bash
npx wrangler delete "$WORKER_NAME" --force || true
```

To:
```bash
npx wrangler delete --name "$WORKER_NAME" --force || true
```

This matches the pattern used in the deployment workflows.

## Test plan
- [ ] Verify the cleanup workflow runs successfully when a PR is closed
- [ ] Check that the ephemeral worker is actually deleted from Cloudflare
- [ ] Confirm no "worker name must be defined" errors appear