### PR TITLE
fix: make cleanup workflow check if worker exists before deletion

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -20,17 +20,31 @@ jobs:
           node-version: '20'
       
       - name: Delete ephemeral worker
+        id: delete-worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           WORKER_NAME="phialo-pr-${{ github.event.pull_request.number }}"
           
-          # Delete the worker
-          npx wrangler delete --name "$WORKER_NAME" --force || true
+          # Check if the worker exists
+          echo "Checking if worker $WORKER_NAME exists..."
+          
+          # Use wrangler deployments list to check if worker exists
+          # The command will return exit code 0 even if worker doesn't exist
+          WORKER_EXISTS=$(npx wrangler deployments list --name "$WORKER_NAME" 2>&1 | grep -q "No deployments found" && echo "false" || echo "true")
+          
+          if [ "$WORKER_EXISTS" = "true" ]; then
+            echo "Worker $WORKER_NAME exists, deleting..."
+            npx wrangler delete --name "$WORKER_NAME" --force
+            echo "worker_deleted=true" >> $GITHUB_OUTPUT
+          else
+            echo "Worker $WORKER_NAME does not exist, skipping deletion"
+            echo "worker_deleted=false" >> $GITHUB_OUTPUT
+          fi
       
       - name: Comment on PR
-        if: always()
+        if: steps.delete-worker.outputs.worker_deleted == 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- Cleanup workflow now checks if an ephemeral worker exists before attempting deletion
- Only posts the cleanup comment if a worker was actually deleted
- Provides clearer logging about worker existence

## Problem
The cleanup workflow runs on ALL closed PRs, even those that never had ephemeral preview environments created. This leads to:
1. Attempting to delete non-existent workers (causing API errors in logs)
2. Posting misleading "Preview Cleaned Up" comments on PRs that never had previews

Example: PR #117 only modified workflow files, so no preview was created, but cleanup still ran and posted a comment.

## Solution
Modified the cleanup workflow to:
1. Check if the worker exists using `wrangler deployments list`
2. Only attempt deletion if the worker exists
3. Only post the cleanup comment if a worker was actually deleted
4. Provide clear logging about whether a worker existed

## Implementation Details
- Added an `id` to the delete-worker step to capture output
- Use `GITHUB_OUTPUT` to pass the deletion status to the comment step
- The comment step now has a conditional: `if: steps.delete-worker.outputs.worker_deleted == 'true'`

## Test plan
- [ ] Create a PR that triggers an ephemeral preview (modifies files in `phialo-design/**` or `workers/**`)
- [ ] Close the PR and verify the worker is deleted and comment is posted
- [ ] Create a PR that does NOT trigger a preview (e.g., only modifies this workflow)
- [ ] Close the PR and verify no "Preview Cleaned Up" comment is posted
- [ ] Check workflow logs show clear messages about worker existence