### PR TITLE
feat: Add automated Cloudflare PR preview deployments

### DIFF
--- a/.github/workflows/cloudflare-pr-cleanup.yml
+++ b/.github/workflows/cloudflare-pr-cleanup.yml
@@ -1,0 +1,48 @@
+name: Cloudflare PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    name: Clean up PR Preview Worker
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Delete PR preview worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: delete --name phialo-pr-${{ github.event.pull_request.number }} --force
+        continue-on-error: true
+      
+      - name: Comment on PR about cleanup
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr_number = context.issue.number;
+            
+            // Create a unique identifier for this comment
+            const identifier = '<!-- cloudflare-preview-cleanup -->';
+            
+            const body = `${identifier}
+## 🧹 Preview Deployment Cleaned Up
+
+The Cloudflare preview deployment for this PR has been removed.
+`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              body: body
+            });

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -1,0 +1,127 @@
+name: Cloudflare PR Preview Deployment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'phialo-design/**'
+      - 'workers/**'
+      - '.github/workflows/cloudflare-pr-preview.yml'
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    name: Deploy PR Preview to Cloudflare Workers
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'phialo-design/package-lock.json'
+      
+      - name: Install dependencies
+        working-directory: ./phialo-design
+        run: npm ci
+      
+      - name: Build Astro site
+        working-directory: ./phialo-design
+        run: npm run build
+        
+      - name: Create temporary wrangler config
+        working-directory: ./workers
+        run: |
+          cat > wrangler-pr-${{ github.event.pull_request.number }}.toml << EOF
+          name = "phialo-pr-${{ github.event.pull_request.number }}"
+          main = "src/index.ts"
+          compatibility_date = "2024-01-01"
+          workers_dev = true
+          
+          [site]
+          bucket = "../phialo-design/dist"
+          
+          [vars]
+          ENVIRONMENT = "preview"
+          PR_NUMBER = "${{ github.event.pull_request.number }}"
+          EOF
+      
+      - name: Deploy to Cloudflare Workers
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: 'workers'
+          command: deploy --config wrangler-pr-${{ github.event.pull_request.number }}.toml
+      
+      - name: Extract deployment URL
+        id: extract-url
+        working-directory: ./workers
+        run: |
+          # The deployment URL will be in the format: https://phialo-pr-<number>.meise.workers.dev
+          PREVIEW_URL="https://phialo-pr-${{ github.event.pull_request.number }}.meise.workers.dev"
+          echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+      
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr_number = context.issue.number;
+            const preview_url = '${{ steps.extract-url.outputs.preview_url }}';
+            
+            // Create a unique identifier for this comment
+            const identifier = '<!-- cloudflare-preview-deployment -->';
+            
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+            });
+            
+            const existingComment = comments.find(comment => 
+              comment.body?.includes(identifier)
+            );
+            
+            const body = `${identifier}
+## 🚀 Cloudflare Preview Deployment
+
+Your preview deployment is ready!
+
+🔗 **Preview URL**: ${preview_url}
+
+This deployment will be automatically updated when you push new commits to this PR.
+`;
+            
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body: body
+              });
+            }
+      
+      - name: Clean up temporary config
+        if: always()
+        working-directory: ./workers
+        run: |
+          rm -f wrangler-pr-${{ github.event.pull_request.number }}.toml

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -42,11 +42,12 @@ jobs:
           cat > wrangler-pr-${{ github.event.pull_request.number }}.toml << EOF
           name = "phialo-pr-${{ github.event.pull_request.number }}"
           main = "src/index.ts"
-          compatibility_date = "2024-01-01"
+          compatibility_date = "2024-09-25"
           workers_dev = true
           
-          [site]
-          bucket = "../phialo-design/dist"
+          [assets]
+          directory = "../phialo-design/dist"
+          binding = "ASSETS"
           
           [vars]
           ENVIRONMENT = "preview"

--- a/workers/scripts/deploy-ephemeral.sh
+++ b/workers/scripts/deploy-ephemeral.sh
@@ -16,11 +16,12 @@ WORKER_NAME="phialo-pr-${PR_NUMBER}"
 cat > wrangler-ephemeral.toml << EOF
 name = "${WORKER_NAME}"
 main = "src/index.ts"
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-09-25"
 workers_dev = true
 
-[site]
-bucket = "../phialo-design/dist"
+[assets]
+directory = "../phialo-design/dist"
+binding = "ASSETS"
 
 [vars]
 ENVIRONMENT = "preview"


### PR DESCRIPTION
## Summary
This PR implements automated Cloudflare Workers preview deployments for pull requests, providing instant preview URLs for testing changes before merging.

## Features
- 🚀 **Automatic PR Preview Deployments**: Every PR gets its own preview environment at `https://phialo-pr-{number}.meise.workers.dev`
- 💬 **PR Comments with Preview URL**: Bot automatically comments on PRs with the preview URL
- 🔄 **Auto-rebuild on Updates**: Preview automatically rebuilds when new commits are pushed
- 🧹 **Automatic Cleanup**: Preview deployments are removed when PRs are closed
- ✅ **Modern Assets Binding**: Uses Cloudflare's latest `[assets]` configuration instead of deprecated `[site]`

## Implementation Details
- Added `.github/workflows/cloudflare-pr-preview.yml` for deploying PR previews
- Added `.github/workflows/cloudflare-pr-cleanup.yml` for cleaning up closed PRs
- Updated `workers/scripts/deploy-ephemeral.sh` to use correct assets binding configuration
- Preview URLs are posted as comments on PRs (replaces GitHub's auth callback URL)

## Testing
Once this PR is merged, all future PRs will automatically get preview deployments. The workflow will:
1. Build the Astro site
2. Deploy to Cloudflare Workers with a unique URL
3. Post the preview URL as a comment
4. Update the deployment on new commits
5. Clean up when the PR is closed

## Example Preview URL Format
```
https://phialo-pr-123.meise.workers.dev
```

## Security
- Uses GitHub secrets for Cloudflare API credentials
- Follows Cloudflare and GitHub Actions best practices
- Preview deployments are isolated and temporary

Fixes the issue where PR comments showed GitHub's user authorization callback URL instead of the actual preview URL.