### PR TITLE
Fix: Resolve YAML syntax errors in Cloudflare workflows

### DIFF
--- a/.github/workflows/cloudflare-pr-cleanup.yml
+++ b/.github/workflows/cloudflare-pr-cleanup.yml
@@ -34,11 +34,9 @@ jobs:
             // Create a unique identifier for this comment
             const identifier = '<!-- cloudflare-preview-cleanup -->';
             
-            const body = `${identifier}
-## 🧹 Preview Deployment Cleaned Up
-
-The Cloudflare preview deployment for this PR has been removed.
-`;
+            const body = identifier + '\n' +
+              '## 🧹 Preview Deployment Cleaned Up\n\n' +
+              'The Cloudflare preview deployment for this PR has been removed.\n';
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -93,15 +93,11 @@ jobs:
               comment.body?.includes(identifier)
             );
             
-            const body = `${identifier}
-## 🚀 Cloudflare Preview Deployment
-
-Your preview deployment is ready!
-
-🔗 **Preview URL**: ${preview_url}
-
-This deployment will be automatically updated when you push new commits to this PR.
-`;
+            const body = identifier + '\n' +
+              '## 🚀 Cloudflare Preview Deployment\n\n' +
+              'Your preview deployment is ready!\n\n' +
+              '🔗 **Preview URL**: ' + preview_url + '\n\n' +
+              'This deployment will be automatically updated when you push new commits to this PR.\n';
             
             if (existingComment) {
               // Update existing comment


### PR DESCRIPTION
## Summary
- Fixed YAML syntax errors in cloudflare-pr-preview.yml and cloudflare-pr-cleanup.yml
- Both workflows were failing immediately due to multiline JavaScript template literals being incorrectly parsed by YAML
- Replaced template literals with string concatenation to ensure proper YAML parsing

## Problem
The workflows were failing with "This run likely failed because of a workflow file issue" because the YAML parser couldn't handle the multiline template literals in the JavaScript code blocks within the `script:` sections.

## Solution
Changed from template literals to string concatenation:
```javascript
// Before (causing YAML parsing error)
const body = `${identifier}
## 🚀 Cloudflare Preview Deployment
...`;

// After (YAML-safe)
const body = identifier + '\n' +
  '## 🚀 Cloudflare Preview Deployment\n\n' +
  ...;
```

## Test plan
- [x] Verified both YAML files pass linting with `npx yaml-lint`
- [x] All workflow files in `.github/workflows/` now pass YAML validation
- [ ] Workflows should run successfully after merge