### PR TITLE
fix: add top-level permissions to cleanup-artifacts workflow

### DIFF
--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -268,6 +268,8 @@ jobs:
     needs: [cleanup-artifacts, cleanup-caches, cleanup-workflow-runs]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Final Summary
         run: |

--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -23,6 +23,11 @@ on:
         default: false
         type: boolean
 
+# Default permissions for all jobs
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   cleanup-artifacts:
     name: Cleanup Old Artifacts

--- a/.github/workflows/cloudflare-pr-cleanup.yml
+++ b/.github/workflows/cloudflare-pr-cleanup.yml
@@ -34,11 +34,9 @@ jobs:
             // Create a unique identifier for this comment
             const identifier = '<!-- cloudflare-preview-cleanup -->';
             
-            const body = `${identifier}
-## 🧹 Preview Deployment Cleaned Up
-
-The Cloudflare preview deployment for this PR has been removed.
-`;
+            const body = identifier + '\n' +
+              '## 🧹 Preview Deployment Cleaned Up\n\n' +
+              'The Cloudflare preview deployment for this PR has been removed.\n';
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -93,15 +93,11 @@ jobs:
               comment.body?.includes(identifier)
             );
             
-            const body = `${identifier}
-## 🚀 Cloudflare Preview Deployment
-
-Your preview deployment is ready!
-
-🔗 **Preview URL**: ${preview_url}
-
-This deployment will be automatically updated when you push new commits to this PR.
-`;
+            const body = identifier + '\n' +
+              '## 🚀 Cloudflare Preview Deployment\n\n' +
+              'Your preview deployment is ready!\n\n' +
+              '🔗 **Preview URL**: ' + preview_url + '\n\n' +
+              'This deployment will be automatically updated when you push new commits to this PR.\n';
             
             if (existingComment) {
               // Update existing comment


### PR DESCRIPTION
## Summary
- Add top-level permissions declaration to cleanup-artifacts workflow to fix CodeQL security alert
- Resolves the "Workflow does not contain permissions" warning at line 267

## Changes
- Added default permissions block at the top of the workflow:
  - `contents: read` for repository access
  - `actions: write` for artifact/cache deletion operations

## Test plan
- [x] Verify YAML syntax is valid
- [ ] Check that CodeQL alert is resolved after merge
- [ ] Confirm workflow still has necessary permissions to delete artifacts

## Context
This addresses the CodeQL security alert about missing workflow permissions. The workflow needs explicit permissions to perform cleanup operations on artifacts, caches, and workflow runs.