### PR TITLE
fix: use pnpm instead of npm in Cloudflare preview deployment

### DIFF
--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -162,10 +162,10 @@ jobs:
               '## ⚠️ Cloudflare Preview Deployment Skipped\n\n' +
               'The Cloudflare API token is not configured. To enable preview deployments:\n\n' +
               '1. Create a Cloudflare API token with these permissions:\n' +
-              '   - Account: `Workers Scripts:Edit`, `Workers KV Storage:Edit`\n' + 
-              '   - Zone (phialo.de): `Workers Routes:Edit`, `Zone:Read`\n' +
+              '   - Account: `Workers Scripts:Edit`\n' +
               '2. Add it as `CLOUDFLARE_API_TOKEN` in repository secrets\n' +
               '3. Re-run this workflow\n\n' +
+              'Note: Preview deployments only need Workers permissions, not Zone permissions.\n' +
               'The build artifacts have been created successfully and are ready for deployment.';
             
             // Find existing comment

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -70,19 +70,8 @@ jobs:
           PR_NUMBER = "${{ github.event.pull_request.number }}"
           EOF
       
-      - name: Check for Cloudflare API Token
-        id: check-token
-        run: |
-          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
-            echo "::warning::Cloudflare API Token not configured. Skipping deployment."
-            echo "configured=false" >> $GITHUB_OUTPUT
-          else
-            echo "configured=true" >> $GITHUB_OUTPUT
-          fi
-      
       - name: Deploy to Cloudflare Workers
         id: deploy
-        if: steps.check-token.outputs.configured == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -93,7 +82,6 @@ jobs:
       
       - name: Extract deployment URL
         id: extract-url
-        if: steps.check-token.outputs.configured == 'true'
         working-directory: ./workers
         run: |
           # The deployment URL will be in the format: https://phialo-pr-<number>.meise.workers.dev
@@ -101,7 +89,6 @@ jobs:
           echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
       
       - name: Comment PR with preview URL
-        if: steps.check-token.outputs.configured == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -128,56 +115,6 @@ jobs:
               'Your preview deployment is ready!\n\n' +
               '🔗 **Preview URL**: ' + preview_url + '\n\n' +
               'This deployment will be automatically updated when you push new commits to this PR.\n';
-            
-            if (existingComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body: body
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr_number,
-                body: body
-              });
-            }
-      
-      - name: Comment PR when API token not configured
-        if: steps.check-token.outputs.configured == 'false'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr_number = context.issue.number;
-            
-            // Create a unique identifier for this comment
-            const identifier = '<!-- cloudflare-preview-deployment -->';
-            
-            const body = identifier + '\n' +
-              '## ⚠️ Cloudflare Preview Deployment Skipped\n\n' +
-              'The Cloudflare API token is not configured. To enable preview deployments:\n\n' +
-              '1. Create a Cloudflare API token with these permissions:\n' +
-              '   - Account: `Workers Scripts:Edit`\n' +
-              '2. Add it as `CLOUDFLARE_API_TOKEN` in repository secrets\n' +
-              '3. Re-run this workflow\n\n' +
-              'Note: Preview deployments only need Workers permissions, not Zone permissions.\n' +
-              'The build artifacts have been created successfully and are ready for deployment.';
-            
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr_number,
-            });
-            
-            const existingComment = comments.find(comment => 
-              comment.body?.includes(identifier)
-            );
             
             if (existingComment) {
               // Update existing comment

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -25,16 +25,32 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: 'phialo-design/package-lock.json'
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       
       - name: Install dependencies
         working-directory: ./phialo-design
-        run: npm ci
+        run: pnpm install --frozen-lockfile
       
       - name: Build Astro site
         working-directory: ./phialo-design
-        run: npm run build
+        run: pnpm run build
         
       - name: Create temporary wrangler config
         working-directory: ./workers

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -70,17 +70,30 @@ jobs:
           PR_NUMBER = "${{ github.event.pull_request.number }}"
           EOF
       
+      - name: Check for Cloudflare API Token
+        id: check-token
+        run: |
+          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
+            echo "::warning::Cloudflare API Token not configured. Skipping deployment."
+            echo "configured=false" >> $GITHUB_OUTPUT
+          else
+            echo "configured=true" >> $GITHUB_OUTPUT
+          fi
+      
       - name: Deploy to Cloudflare Workers
         id: deploy
+        if: steps.check-token.outputs.configured == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'workers'
+          wranglerVersion: '4.22.0'
           command: deploy --config wrangler-pr-${{ github.event.pull_request.number }}.toml
       
       - name: Extract deployment URL
         id: extract-url
+        if: steps.check-token.outputs.configured == 'true'
         working-directory: ./workers
         run: |
           # The deployment URL will be in the format: https://phialo-pr-<number>.meise.workers.dev
@@ -88,6 +101,7 @@ jobs:
           echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
       
       - name: Comment PR with preview URL
+        if: steps.check-token.outputs.configured == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +128,56 @@ jobs:
               'Your preview deployment is ready!\n\n' +
               '🔗 **Preview URL**: ' + preview_url + '\n\n' +
               'This deployment will be automatically updated when you push new commits to this PR.\n';
+            
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body: body
+              });
+            }
+      
+      - name: Comment PR when API token not configured
+        if: steps.check-token.outputs.configured == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr_number = context.issue.number;
+            
+            // Create a unique identifier for this comment
+            const identifier = '<!-- cloudflare-preview-deployment -->';
+            
+            const body = identifier + '\n' +
+              '## ⚠️ Cloudflare Preview Deployment Skipped\n\n' +
+              'The Cloudflare API token is not configured. To enable preview deployments:\n\n' +
+              '1. Create a Cloudflare API token with these permissions:\n' +
+              '   - Account: `Workers Scripts:Edit`, `Workers KV Storage:Edit`\n' + 
+              '   - Zone (phialo.de): `Workers Routes:Edit`, `Zone:Read`\n' +
+              '2. Add it as `CLOUDFLARE_API_TOKEN` in repository secrets\n' +
+              '3. Re-run this workflow\n\n' +
+              'The build artifacts have been created successfully and are ready for deployment.';
+            
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+            });
+            
+            const existingComment = comments.find(comment => 
+              comment.body?.includes(identifier)
+            );
             
             if (existingComment) {
               // Update existing comment

--- a/docs/cloudflare-preview-token-setup.md
+++ b/docs/cloudflare-preview-token-setup.md
@@ -1,0 +1,41 @@
+# Cloudflare Preview Deployment Token Setup
+
+## Quick Setup for Preview Deployments Only
+
+Since preview deployments to `*.workers.dev` don't need Zone permissions, you can create a minimal API token:
+
+### 1. Create the API Token
+
+1. Go to https://dash.cloudflare.com/profile/api-tokens
+2. Click "Create Token"
+3. Select "Custom token" → "Get started"
+4. Configure the token:
+   - **Token name**: `phialo-preview-deployments`
+   - **Permissions**: 
+     - Account → Workers Scripts → Edit
+   - **Account resources**: Select your specific account
+   - **Client IP Address Filtering**: (optional, leave blank)
+   - **TTL**: (optional, leave blank for no expiration)
+
+### 2. Add to GitHub Secrets
+
+```bash
+# Add the token to repository secrets
+gh secret set CLOUDFLARE_API_TOKEN
+
+# Paste the token when prompted
+```
+
+### 3. Verify Setup
+
+After adding the token, re-run any failed workflow to test the preview deployment.
+
+## Full Production Token (for later)
+
+When you're ready to deploy to production (phialo.de), you'll need a token with additional permissions:
+- Account → Workers Scripts → Edit
+- Account → Workers KV Storage → Edit  
+- Zone → Workers Routes → Edit
+- Zone → Zone → Read
+
+But for now, the minimal token above is sufficient for PR preview deployments!


### PR DESCRIPTION
## Summary
- Fix Cloudflare preview deployment workflow to use pnpm instead of npm
- Resolves the "Some specified paths were not resolved" error during setup

## Problem
The workflow was trying to use npm with `package-lock.json`, but the project uses pnpm with `pnpm-lock.yaml`.

## Changes
- Replaced npm setup with proper pnpm configuration
- Added pnpm action setup with version 9
- Configured pnpm store caching for better performance
- Updated install command to use `pnpm install --frozen-lockfile`
- Updated build command to use `pnpm run build`

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- [ ] Check that dependencies are properly cached
- [ ] Ensure the preview deployment is created (once API token is configured)