### PR TITLE
Fix hamburger menu opacity/effect (Issue #150)

### DIFF
--- a/phialo-design/src/shared/navigation/MobileMenu.tsx
+++ b/phialo-design/src/shared/navigation/MobileMenu.tsx
@@ -60,16 +60,16 @@ export default function MobileMenu({ isOpen, onClose, navItems, currentPath, isE
     <div className="fixed inset-0 z-50 lg:hidden">
       {/* Backdrop */}
       <div 
-        className="fixed inset-0 bg-midnight/20 backdrop-blur-sm"
+        className="fixed inset-0 bg-midnight/30 backdrop-blur-md"
         onClick={onClose}
         data-testid="mobile-menu-backdrop"
       />
       
       {/* Menu Panel */}
-      <div className="fixed inset-y-0 right-0 w-full max-w-sm bg-white shadow-2xl" data-testid="mobile-menu-panel">
+      <div className="fixed inset-y-0 right-0 w-full max-w-sm bg-theme-background/95 backdrop-blur-sm border-l border-theme-border shadow-2xl" data-testid="mobile-menu-panel">
         <div className="flex flex-col h-full">
           {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-gray-100">
+          <div className="flex items-center justify-between p-6 border-b border-theme-border/50">
             <h2 className="font-display text-xl font-medium text-midnight">
               {isEnglish ? 'Menu' : 'Menü'}
             </h2>
@@ -112,7 +112,7 @@ export default function MobileMenu({ isOpen, onClose, navItems, currentPath, isE
           </nav>
           
           {/* CTA */}
-          <div className="p-6 border-t border-gray-100">
+          <div className="p-6 border-t border-theme-border/50">
             <a
               href={isEnglish ? '/en/contact' : '/contact'}
               onClick={onClose}


### PR DESCRIPTION
## Summary

This PR addresses issue #150 by applying the frosted glass effect to the hamburger menu flyout to ensure visual distinction between the menu and background content.

## Changes

- Applied translucent frosted glass effect to mobile menu panel (matching navbar styling)
- Changed background from solid white to `bg-theme-background/95 backdrop-blur-sm`
- Enhanced backdrop overlay blur from `backdrop-blur-sm` to `backdrop-blur-md`
- Updated border colors to use `border-theme-border` for consistency
- Ensured the mobile menu now has the same glass morphism effect as the scrolled navbar

## Visual Changes

Before: Completely transparent menu with text behind it fully visible
After: Frosted glass effect that maintains visual hierarchy and readability

## Testing

- [x] Tested on mobile viewport sizes
- [x] Verified frosted glass effect appears correctly
- [x] Confirmed text readability is improved
- [x] Ensured consistent appearance with navbar glass effect
- [x] No console errors or hydration issues
- [x] Linting and type checking pass

## Screenshots

The mobile menu now matches the translucent frosted glass design system used throughout the site, providing a cohesive visual experience.

Fixes #150