### PR TITLE
feat: Update social media links (#149)

### DIFF
--- a/phialo-design/src/features/contact/components/ContactSection.astro
+++ b/phialo-design/src/features/contact/components/ContactSection.astro
@@ -102,7 +102,7 @@ const t = translations[isEnglish ? 'en' : 'de'];
         <p class="text-gray-300 mb-6">{t.socialTitle}</p>
         <div class="flex justify-center space-x-6">
           <a 
-            href="https://instagram.com/phialo_design" 
+            href="https://www.instagram.com/phialo_design/" 
             target="_blank" 
             rel="noopener noreferrer"
             class="w-12 h-12 bg-white/10 rounded-full flex items-center justify-center hover:bg-gold/20 transition-colors group"

--- a/phialo-design/src/features/portfolio/components/PortfolioSection.tsx
+++ b/phialo-design/src/features/portfolio/components/PortfolioSection.tsx
@@ -149,7 +149,7 @@ export default function Portfolio({ lang = 'de' }: PortfolioProps) {
           </p>
           <div className="text-center">
             <a 
-              href="https://instagram.com/phialo_design" 
+              href="https://www.instagram.com/phialo_design/" 
               target="_blank" 
               rel="noopener noreferrer"
               className="inline-flex items-center text-gold hover:text-gold/80 font-medium transition-colors"

--- a/phialo-design/src/shared/navigation/Footer.astro
+++ b/phialo-design/src/shared/navigation/Footer.astro
@@ -125,7 +125,7 @@ const getLocalizedHref = (href: string) => isEnglish ? `/en${href}` : href;
         <!-- Social Links -->
         <div class="flex items-center gap-4 pt-4">
           <a 
-            href="https://linkedin.com/company/phialo-design" 
+            href="https://www.linkedin.com/in/gesa-pickbrenner/" 
             target="_blank" 
             rel="noopener noreferrer"
             class="p-2 text-theme-text-secondary hover:text-theme-text-primary transition-colors"
@@ -143,7 +143,7 @@ const getLocalizedHref = (href: string) => isEnglish ? `/en${href}` : href;
             <Youtube size={20} />
           </a>
           <a 
-            href="https://instagram.com/phialodesign" 
+            href="https://www.instagram.com/phialo_design/" 
             target="_blank" 
             rel="noopener noreferrer"
             class="p-2 text-theme-text-secondary hover:text-theme-text-primary transition-colors"

--- a/phialo-design/src/test/Portfolio.test.tsx
+++ b/phialo-design/src/test/Portfolio.test.tsx
@@ -308,7 +308,7 @@ describe('Portfolio Component', () => {
     render(<Portfolio />);
     
     const instagramLink = screen.getByText('Portfolio auf Instagram').closest('a');
-    expect(instagramLink).toHaveAttribute('href', 'https://instagram.com/phialo_design');
+    expect(instagramLink).toHaveAttribute('href', 'https://www.instagram.com/phialo_design/');
     expect(instagramLink).toHaveAttribute('target', '_blank');
     expect(instagramLink).toHaveAttribute('rel', 'noopener noreferrer');  });
 


### PR DESCRIPTION
## Summary
- Updated LinkedIn link from company page to Gesa Pickbrenner's personal profile
- Standardized all Instagram links to use the www prefix for consistency
- Updated corresponding test to match new URL format

## Changes Made
1. **Footer.astro**: Updated both LinkedIn and Instagram URLs
2. **PortfolioSection.tsx**: Updated Instagram URL to include www prefix
3. **ContactSection.astro**: Updated Instagram URL to include www prefix  
4. **Portfolio.test.tsx**: Updated test expectation for Instagram URL

## Test Plan
- [x] Verified all social media links are clickable and open in new tabs
- [x] Checked that links have proper security attributes (target="_blank", rel="noopener noreferrer")
- [x] Ran lint and typecheck (existing errors unrelated to changes)
- [x] Confirmed dev server is running and changes are visible

Fixes #149