### PR TITLE
Fix: add 20px right margin to header 'Request Project' button

### DIFF
--- a/phialo-design/src/shared/navigation/Header.astro
+++ b/phialo-design/src/shared/navigation/Header.astro
@@ -43,7 +43,7 @@ const logoAriaLabel = isEnglish ? 'Phialo Design Homepage' : 'Phialo Design Star
       <!-- CTA Button -->
       <a 
         href={ctaHref}
-        class="hidden lg:inline-flex items-center px-6 py-2 text-sm font-medium text-theme-accent border border-theme-accent rounded-full hover:bg-theme-accent hover:text-theme-accent-text transition-all duration-200"
+        class="hidden lg:inline-flex items-center px-6 py-2 mr-5 text-sm font-medium text-theme-accent border border-theme-accent rounded-full hover:bg-theme-accent hover:text-theme-accent-text transition-all duration-200"
       >
         {ctaLabel}
       </a>


### PR DESCRIPTION
## Summary
- Added `mr-5` (20px) right margin to the "Request Project" button in the header
- Ensures proper spacing from the edge of the viewport on desktop screens
- Tested in both German and English versions

## Changes
- Modified `src/shared/navigation/Header.astro` to add the `mr-5` utility class to the CTA button

## Testing
- ✅ Tested on German version (http://localhost:4321)
- ✅ Tested on English version (http://localhost:4321/en)
- ✅ Verified the button displays correctly with proper spacing
- ✅ Ran lint and typecheck commands

## Screenshots
The button now has proper spacing from the right edge in both language versions.

Fixes #195