### PR TITLE
feat: Add daily E2E test report automation

### DIFF
--- a/.github/workflows/daily-e2e-report.yml
+++ b/.github/workflows/daily-e2e-report.yml
@@ -1,0 +1,261 @@
+name: Daily E2E Test Report
+
+on:
+  schedule:
+    # Run at 3 AM UTC daily (after nightly tests complete)
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      test_date:
+        description: 'Date for the report (YYYY-MM-DD)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  create-daily-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get test date
+        id: date
+        run: |
+          if [ -n "${{ github.event.inputs.test_date }}" ]; then
+            echo "date=${{ github.event.inputs.test_date }}" >> $GITHUB_OUTPUT
+          else
+            echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          fi
+          echo "timestamp=$(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_OUTPUT
+
+      - name: Get nightly test results
+        id: test-results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = '${{ steps.date.outputs.date }}';
+            const dateStart = new Date(date + 'T00:00:00Z');
+            const dateEnd = new Date(date + 'T23:59:59Z');
+            
+            // Get nightly test runs for the date
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'nightly-tests.yml',
+              created: `${dateStart.toISOString()}..${dateEnd.toISOString()}`
+            });
+            
+            let nightlyRun = runs.data.workflow_runs[0];
+            
+            if (!nightlyRun) {
+              core.setOutput('found', 'false');
+              core.setOutput('status', 'not_run');
+              return;
+            }
+            
+            core.setOutput('found', 'true');
+            core.setOutput('run_id', nightlyRun.id);
+            core.setOutput('status', nightlyRun.conclusion || nightlyRun.status);
+            core.setOutput('run_url', nightlyRun.html_url);
+            
+            // Get job details for test statistics
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: nightlyRun.id
+            });
+            
+            // Count e2e test jobs
+            const e2eJobs = jobs.data.jobs.filter(job => 
+              job.name.includes('e2e-tests') || 
+              job.name.includes('E2E Tests')
+            );
+            
+            const totalE2eTests = e2eJobs.length;
+            const passedE2eTests = e2eJobs.filter(job => job.conclusion === 'success').length;
+            const failedE2eTests = e2eJobs.filter(job => job.conclusion === 'failure').length;
+            const skippedE2eTests = e2eJobs.filter(job => job.conclusion === 'skipped').length;
+            
+            core.setOutput('total_e2e_tests', totalE2eTests);
+            core.setOutput('passed_e2e_tests', passedE2eTests);
+            core.setOutput('failed_e2e_tests', failedE2eTests);
+            core.setOutput('skipped_e2e_tests', skippedE2eTests);
+            
+            // Get artifact information if available
+            try {
+              const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: nightlyRun.id
+              });
+              
+              const reportArtifact = artifacts.data.artifacts.find(a => 
+                a.name.includes('nightly-test-report')
+              );
+              
+              if (reportArtifact) {
+                core.setOutput('report_url', reportArtifact.archive_download_url);
+              }
+            } catch (error) {
+              console.log('No artifacts found');
+            }
+
+      - name: Find or create daily issue
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = '${{ steps.date.outputs.date }}';
+            const issueTitle = `📊 Daily E2E Test Report - ${date}`;
+            
+            // Search for existing issue
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              labels: 'daily-e2e-report',
+              since: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() // Last 7 days
+            });
+            
+            let existingIssue = issues.data.find(issue => issue.title === issueTitle);
+            
+            const timestamp = '${{ steps.date.outputs.timestamp }}';
+            const runFound = '${{ steps.test-results.outputs.found }}' === 'true';
+            const status = '${{ steps.test-results.outputs.status }}';
+            const runUrl = '${{ steps.test-results.outputs.run_url }}';
+            const totalTests = '${{ steps.test-results.outputs.total_e2e_tests }}' || '0';
+            const passedTests = '${{ steps.test-results.outputs.passed_e2e_tests }}' || '0';
+            const failedTests = '${{ steps.test-results.outputs.failed_e2e_tests }}' || '0';
+            const skippedTests = '${{ steps.test-results.outputs.skipped_e2e_tests }}' || '0';
+            
+            let statusEmoji = '❓';
+            let statusText = 'Unknown';
+            
+            if (!runFound) {
+              statusEmoji = '⏭️';
+              statusText = 'No tests run';
+            } else if (status === 'success') {
+              statusEmoji = '✅';
+              statusText = 'All tests passed';
+            } else if (status === 'failure') {
+              statusEmoji = '❌';
+              statusText = 'Tests failed';
+            } else if (status === 'cancelled') {
+              statusEmoji = '🚫';
+              statusText = 'Tests cancelled';
+            } else if (status === 'startup_failure') {
+              statusEmoji = '🔧';
+              statusText = 'Startup failure';
+            }
+            
+            const body = `## ${statusEmoji} Daily E2E Test Summary
+            
+            **Last Updated**: ${timestamp}
+            **Date**: ${date}
+            **Status**: ${statusText}
+            
+            ### Test Statistics
+            
+            | Metric | Count |
+            |--------|-------|
+            | **Total E2E Tests** | ${totalTests} |
+            | **✅ Passed** | ${passedTests} |
+            | **❌ Failed** | ${failedTests} |
+            | **⏭️ Skipped** | ${skippedTests} |
+            
+            ${runFound ? `### Test Run Details
+            
+            - **Workflow Run**: [View Run](${runUrl})
+            - **Run ID**: ${`${{ steps.test-results.outputs.run_id }}`}
+            ${`${{ steps.test-results.outputs.report_url }}` ? `- **Test Report**: [Download Artifact](${{ steps.test-results.outputs.report_url }})` : ''}
+            
+            ### Test Coverage
+            
+            The nightly E2E tests include:
+            - 🌐 Cross-browser testing (Chromium, Firefox, WebKit)
+            - 📱 Mobile viewport testing
+            - 🎭 Visual regression testing
+            - ⚡ Performance testing (Lighthouse)
+            - 🔒 Security scanning
+            - ♿ Accessibility testing
+            ` : `### ⚠️ No Test Run Found
+            
+            No nightly test run was found for ${date}. This could be due to:
+            - The scheduled workflow was disabled
+            - The workflow failed to start
+            - Infrastructure issues
+            
+            Please check the [workflow configuration](https://github.com/${{ github.repository }}/blob/master/.github/workflows/nightly-tests.yml) and [recent runs](https://github.com/${{ github.repository }}/actions/workflows/nightly-tests.yml).
+            `}
+            
+            ### Actions
+            
+            ${status === 'failure' ? `- [ ] Review failing tests
+            - [ ] Fix identified issues
+            - [ ] Re-run tests if needed` : 
+            status === 'startup_failure' ? `- [ ] Check workflow configuration
+            - [ ] Verify runner availability
+            - [ ] Check for infrastructure issues` :
+            status === 'success' ? `- [x] All tests passed - no action needed` :
+            `- [ ] Investigate why tests didn't run`}
+            
+            ---
+            
+            <details>
+            <summary>About this report</summary>
+            
+            This is an automated daily summary of the nightly E2E test suite. The report is generated at 3 AM UTC and includes:
+            - Test execution status
+            - Pass/fail statistics
+            - Links to detailed results
+            - Action items for failures
+            
+            The full test suite runs in a containerized environment to ensure consistency and includes comprehensive browser, performance, and security testing.
+            </details>`;
+            
+            if (existingIssue) {
+              // Update existing issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: body,
+                state: status === 'success' ? 'closed' : 'open'
+              });
+              
+              console.log(`Updated issue #${existingIssue.number}`);
+              core.setOutput('issue_number', existingIssue.number);
+              core.setOutput('issue_url', existingIssue.html_url);
+            } else {
+              // Create new issue
+              const newIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body: body,
+                labels: ['daily-e2e-report', 'automated', status === 'failure' ? 'test-failure' : 'test-success']
+              });
+              
+              console.log(`Created issue #${newIssue.data.number}`);
+              core.setOutput('issue_number', newIssue.data.number);
+              core.setOutput('issue_url', newIssue.data.html_url);
+            }
+
+      - name: Summary
+        run: |
+          echo "## Daily E2E Test Report Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Date**: ${{ steps.date.outputs.date }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Issue**: [#${{ steps.issue.outputs.issue_number }}](${{ steps.issue.outputs.issue_url }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.test-results.outputs.found }}" == "true" ]; then
+            echo "### Test Results" >> $GITHUB_STEP_SUMMARY
+            echo "- **Status**: ${{ steps.test-results.outputs.status }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Total E2E Tests**: ${{ steps.test-results.outputs.total_e2e_tests }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Passed**: ${{ steps.test-results.outputs.passed_e2e_tests }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Failed**: ${{ steps.test-results.outputs.failed_e2e_tests }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ No test run found for this date" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/docs/how-to/daily-e2e-reports.md
+++ b/docs/how-to/daily-e2e-reports.md
@@ -1,0 +1,194 @@
+# Daily E2E Test Reports
+
+## Overview
+
+The Daily E2E Test Report system provides automated tracking and reporting of nightly end-to-end test results. A GitHub issue is created or updated daily with comprehensive test statistics, pass/fail information, and actionable items.
+
+## Features
+
+- **Automated Daily Reports**: Runs at 3 AM UTC (after nightly tests complete)
+- **Comprehensive Statistics**: Tracks total tests, passed, failed, and skipped
+- **Issue Management**: Creates or updates a daily issue with results
+- **Failure Tracking**: Highlights failures and provides action items
+- **Historical Records**: Maintains a searchable history of test results
+
+## Report Contents
+
+Each daily report includes:
+
+1. **Test Summary**
+   - Overall status (✅ Passed, ❌ Failed, 🔧 Startup failure, etc.)
+   - Last update timestamp
+   - Test date
+
+2. **Test Statistics**
+   - Total E2E tests run
+   - Number passed
+   - Number failed
+   - Number skipped
+
+3. **Run Details** (if tests ran)
+   - Link to workflow run
+   - Run ID
+   - Download link for test artifacts
+
+4. **Test Coverage Information**
+   - Cross-browser testing details
+   - Mobile viewport testing
+   - Visual regression testing
+   - Performance testing
+   - Security scanning
+   - Accessibility testing
+
+5. **Action Items**
+   - Contextual tasks based on test results
+   - Checkboxes for tracking resolution
+
+## Usage
+
+### Automatic Reports
+
+The daily report runs automatically via GitHub Actions:
+- Schedule: 3 AM UTC daily
+- Creates/updates issue with label `daily-e2e-report`
+- Closes issues automatically when all tests pass
+
+### Manual Report Generation
+
+To generate a report for a specific date:
+
+```bash
+# Generate report for today
+./scripts/create-daily-e2e-report.sh
+
+# Generate report for specific date
+./scripts/create-daily-e2e-report.sh 2025-07-01
+```
+
+Or via GitHub Actions UI:
+1. Go to Actions → Daily E2E Test Report
+2. Click "Run workflow"
+3. Optionally specify a date (YYYY-MM-DD)
+4. Click "Run workflow"
+
+### Finding Reports
+
+Daily reports can be found by:
+- Label: `daily-e2e-report`
+- Title format: `📊 Daily E2E Test Report - YYYY-MM-DD`
+- In Issues tab with automated reports
+
+## Report States
+
+### ✅ All Tests Passed
+- Issue is automatically closed
+- No action items required
+- Green success label applied
+
+### ❌ Tests Failed
+- Issue remains open
+- Failure details provided
+- Action items for investigation
+- Red failure label applied
+
+### 🔧 Startup Failure
+- Indicates workflow configuration issues
+- Provides troubleshooting steps
+- Requires infrastructure investigation
+
+### ⏭️ No Tests Run
+- No nightly test execution found
+- Provides possible causes
+- Links to workflow configuration
+
+## Troubleshooting
+
+### No Daily Report Created
+
+1. Check if workflow is enabled:
+   ```bash
+   gh workflow list | grep "Daily E2E"
+   ```
+
+2. Check recent runs:
+   ```bash
+   gh run list --workflow=daily-e2e-report.yml
+   ```
+
+3. Enable workflow if disabled:
+   ```bash
+   gh workflow enable daily-e2e-report.yml
+   ```
+
+### Incorrect Test Statistics
+
+The report pulls data from the nightly test run. If statistics seem wrong:
+1. Check the nightly test run for the date
+2. Verify job names include "e2e-tests" or "E2E Tests"
+3. Check workflow logs for parsing errors
+
+### Missing Test Runs
+
+If no test run is found for a date:
+1. Verify nightly tests are scheduled and enabled
+2. Check for infrastructure issues on that date
+3. Look for workflow startup failures
+
+## Configuration
+
+The daily report workflow can be customized in `.github/workflows/daily-e2e-report.yml`:
+
+- **Schedule**: Modify the cron expression
+- **Labels**: Update issue labels
+- **Report Format**: Customize the issue body template
+- **Test Detection**: Adjust job name filters
+
+## Integration with Nightly Tests
+
+The daily report system works in conjunction with:
+- `nightly-tests.yml`: The main test execution workflow
+- Test artifacts: Downloaded and linked in reports
+- Failure notifications: Separate from immediate failure alerts
+
+## Best Practices
+
+1. **Review Daily**: Check the daily report each morning
+2. **Act on Failures**: Address failing tests promptly
+3. **Track Trends**: Monitor for flaky tests or recurring issues
+4. **Update Documentation**: Keep test coverage section current
+5. **Clean Up**: Periodically close old report issues
+
+## Example Report
+
+```markdown
+## ✅ Daily E2E Test Summary
+
+**Last Updated**: 2025-07-02 03:00:15 UTC
+**Date**: 2025-07-02
+**Status**: All tests passed
+
+### Test Statistics
+
+| Metric | Count |
+|--------|-------|
+| **Total E2E Tests** | 18 |
+| **✅ Passed** | 18 |
+| **❌ Failed** | 0 |
+| **⏭️ Skipped** | 0 |
+
+### Test Run Details
+
+- **Workflow Run**: [View Run](https://github.com/barde/phialoastro/actions/runs/12345)
+- **Run ID**: 12345
+- **Test Report**: [Download Artifact](...)
+
+### Actions
+
+- [x] All tests passed - no action needed
+```
+
+## Related Documentation
+
+- [Nightly Tests Guide](./nightly-tests.md)
+- [E2E Testing Strategy](./E2E-TESTING-STRATEGY.md)
+- [CI/CD Overview](../architecture/CI-CD-OVERVIEW.md)

--- a/scripts/create-daily-e2e-report.sh
+++ b/scripts/create-daily-e2e-report.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Script to manually create daily E2E test report
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Creating Daily E2E Test Report${NC}"
+
+# Get date parameter or use today
+DATE=${1:-$(date -u +%Y-%m-%d)}
+
+echo -e "${YELLOW}Date: ${DATE}${NC}"
+
+# Trigger the workflow
+echo "Triggering daily E2E report workflow..."
+gh workflow run daily-e2e-report.yml \
+  -f test_date="${DATE}"
+
+echo -e "${GREEN}✓ Workflow triggered successfully${NC}"
+echo "Check the workflow run at: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/workflows/daily-e2e-report.yml"
+
+# Wait a bit and check status
+echo "Waiting for workflow to start..."
+sleep 5
+
+# Get the latest run
+RUN_ID=$(gh run list --workflow=daily-e2e-report.yml --limit=1 --json databaseId -q '.[0].databaseId')
+
+if [ -n "$RUN_ID" ]; then
+  echo -e "${GREEN}Workflow started with run ID: ${RUN_ID}${NC}"
+  echo "View run: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/runs/${RUN_ID}"
+else
+  echo -e "${RED}Could not find workflow run${NC}"
+fi


### PR DESCRIPTION
## Summary
- Added automated daily E2E test report generation system
- Creates or updates GitHub issues with comprehensive test statistics
- Provides visibility into nightly test results whether they pass or fail

## What's New
1. **Daily Report Workflow** (`daily-e2e-report.yml`)
   - Runs at 3 AM UTC after nightly tests complete
   - Creates/updates daily issue with test results
   - Tracks total tests, passed, failed, and skipped counts
   - Includes timestamps and links to test runs

2. **Manual Trigger Script** (`create-daily-e2e-report.sh`)
   - Allows on-demand report generation
   - Supports specific date reports
   - Provides immediate feedback

3. **Comprehensive Documentation** (`daily-e2e-reports.md`)
   - Usage instructions
   - Troubleshooting guide
   - Integration details

## Features
- ✅ Automatic daily issue creation/update
- 📊 Test statistics tracking
- 🔗 Links to workflow runs and artifacts
- 📝 Contextual action items based on results
- 🏷️ Proper labeling for easy filtering
- 🔄 Handles all test states (success, failure, startup issues, no run)

## Test Plan
- [x] Workflow YAML validated
- [x] Script tested locally
- [ ] Manual workflow trigger test
- [ ] Verify issue creation
- [ ] Check statistics accuracy

## Related Issues
Addresses the need for better visibility into nightly E2E test results as requested.