### PR TITLE
docs: add Git LFS documentation post-migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ temp/
 
 # Test results
 phialo-design/test-results/
+workers/coverage/
+coverage/
+*.lcov
 *.zip
 *.tar
 *.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,43 @@ npm run deploy:preview     # Deploy to Cloudflare Workers preview
 ./scripts/clean-project.sh # Remove .DS_Store and other junk files
 ```
 
+## Git LFS Requirements
+
+This repository uses Git Large File Storage (LFS) for managing binary files (images, etc.). **Git LFS is REQUIRED** for development and CI/CD.
+
+### Setup Instructions
+```bash
+# Install Git LFS (if not already installed)
+brew install git-lfs  # macOS
+# or
+sudo apt-get install git-lfs  # Ubuntu/Debian
+
+# Initialize Git LFS in your local repository
+git lfs install
+
+# Pull all LFS files
+git lfs pull
+```
+
+### LFS Configuration
+The repository tracks these file types with LFS (defined in `.gitattributes`):
+- `*.jpg` - JPEG images
+- `*.png` - PNG images  
+- `*.webp` - WebP images
+
+### Important Notes
+- **CI/CD requires LFS**: GitHub Actions workflows use `lfs: true` in checkout steps
+- **Check LFS status**: Run `git lfs status` before pushing to ensure files are properly tracked
+- **Storage quotas**: Be aware of GitHub LFS bandwidth and storage limits
+- **Team coordination**: All team members must have Git LFS installed
+
+### Troubleshooting
+If you encounter LFS-related errors:
+1. Ensure Git LFS is installed: `git lfs version`
+2. Pull LFS files: `git lfs pull`
+3. Check tracked files: `git lfs ls-files`
+4. Verify file status: `git lfs status`
+
 ## PR and Development Guidelines
 
 - Always wait for PR post-push checks like e2e tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,30 @@ A luxury jewelry portfolio website built with Astro, React, and TypeScript. Feat
 
 ## 🚀 Quick Start
 
+### Prerequisites
+
+This repository uses Git LFS (Large File Storage) for managing images and other binary files. **You must install Git LFS before cloning:**
+
 ```bash
+# Install Git LFS
+brew install git-lfs  # macOS
+# or
+sudo apt-get install git-lfs  # Ubuntu/Debian
+
+# Initialize Git LFS
+git lfs install
+```
+
+### Setup
+
+```bash
+# Clone the repository (Git LFS files will be downloaded automatically)
+git clone https://github.com/barde/phialoastro.git
+cd phialoastro
+
+# If you already cloned without LFS, pull the LFS files
+git lfs pull
+
 # Install dependencies
 cd phialo-design
 npm install

--- a/scripts/migrate-to-lfs.sh
+++ b/scripts/migrate-to-lfs.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Script to migrate existing image files to Git LFS
+# This script helps with the migration process described in issue #230
+
+set -e
+
+echo "=== Git LFS Migration Helper Script ==="
+echo "This script will help you migrate image files to Git LFS"
+echo ""
+
+# Check if git lfs is installed
+if ! command -v git-lfs &> /dev/null; then
+    echo "❌ Error: Git LFS is not installed!"
+    echo "Please install it first:"
+    echo "  brew install git-lfs  # macOS"
+    echo "  sudo apt-get install git-lfs  # Ubuntu/Debian"
+    exit 1
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "❌ Error: Not in a git repository!"
+    exit 1
+fi
+
+echo "✅ Git LFS is installed"
+echo ""
+
+# Show current status
+echo "📊 Current Status:"
+echo "- Total image files: $(find . -type f \( -name "*.jpg" -o -name "*.png" -o -name "*.webp" \) -not -path "./node_modules/*" -not -path "./.git/*" | wc -l | tr -d ' ')"
+echo "- Files tracked by LFS: $(git lfs ls-files | wc -l | tr -d ' ')"
+echo ""
+
+# Check for uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    echo "⚠️  Warning: You have uncommitted changes!"
+    echo "It's recommended to commit or stash your changes before migrating to LFS."
+    echo ""
+    read -p "Do you want to continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+echo ""
+echo "🔍 Migration Options:"
+echo "1. Migrate ALL image files to LFS (rewrites history - requires force push)"
+echo "2. Track future image files with LFS (no history rewrite)"
+echo "3. Show commands only (dry run)"
+echo ""
+read -p "Select option (1-3): " option
+
+case $option in
+    1)
+        echo ""
+        echo "⚠️  WARNING: This will rewrite git history!"
+        echo "All team members will need to re-clone the repository."
+        echo ""
+        read -p "Are you sure you want to proceed? Type 'yes' to confirm: " confirm
+        if [ "$confirm" != "yes" ]; then
+            echo "Migration cancelled."
+            exit 0
+        fi
+        
+        echo ""
+        echo "📦 Starting migration..."
+        echo "This may take a while for large repositories..."
+        
+        # Migrate existing files in history
+        git lfs migrate import --include="*.jpg,*.png,*.webp" --everything
+        
+        echo ""
+        echo "✅ Migration complete!"
+        echo ""
+        echo "Next steps:"
+        echo "1. Review the changes: git log --oneline -n 10"
+        echo "2. Force push to remote: git push --force-with-lease origin $(git branch --show-current)"
+        echo "3. Notify all team members to re-clone the repository"
+        ;;
+        
+    2)
+        echo ""
+        echo "📦 Tracking future files with LFS..."
+        
+        # Track the files with LFS
+        git lfs track "*.jpg"
+        git lfs track "*.png"
+        git lfs track "*.webp"
+        
+        # Add and commit .gitattributes
+        git add .gitattributes
+        git commit -m "Configure Git LFS tracking for image files"
+        
+        echo ""
+        echo "✅ LFS tracking configured!"
+        echo "Future image files will be stored in LFS."
+        echo ""
+        echo "To convert existing files, you'll need to:"
+        echo "1. Remove them: git rm --cached *.jpg *.png *.webp"
+        echo "2. Re-add them: git add *.jpg *.png *.webp"
+        echo "3. Commit: git commit -m 'Migrate images to LFS'"
+        ;;
+        
+    3)
+        echo ""
+        echo "📝 Dry run - here are the commands that would be executed:"
+        echo ""
+        echo "# For full migration (option 1):"
+        echo "git lfs migrate import --include=\"*.jpg,*.png,*.webp\" --everything"
+        echo "git push --force-with-lease origin $(git branch --show-current)"
+        echo ""
+        echo "# For tracking future files (option 2):"
+        echo "git lfs track \"*.jpg\""
+        echo "git lfs track \"*.png\""
+        echo "git lfs track \"*.webp\""
+        echo "git add .gitattributes"
+        echo "git commit -m \"Configure Git LFS tracking for image files\""
+        ;;
+        
+    *)
+        echo "Invalid option selected."
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "📚 Additional Resources:"
+echo "- Git LFS Tutorial: https://github.com/git-lfs/git-lfs/wiki/Tutorial"
+echo "- Issue #230: https://github.com/barde/phialoastro/issues/230"


### PR DESCRIPTION
## Summary
- Added Git LFS requirements documentation after successful migration
- Created migration helper script for future reference
- Updated README.md and CLAUDE.md with LFS setup instructions

## Context
This PR adds documentation after the successful Git LFS migration completed in issue #230. The repository history has already been rewritten and 70 image files are now tracked with LFS.

## Changes
- **README.md**: Added prerequisites section with Git LFS installation instructions
- **CLAUDE.md**: Added detailed LFS requirements section for AI assistants
- **scripts/migrate-to-lfs.sh**: Created helper script for future migrations

## Related Issue
Closes #230

## Verification
- Repository size reduced from large to 72MB for .git directory
- 70 files successfully tracked by LFS
- Images verified working after `git lfs pull`
- CI/CD should now work correctly with LFS files