### PR TITLE
feat: enable PR preview comments on all pull requests

### DIFF
--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -3,10 +3,6 @@ name: Cloudflare PR Preview Deployment
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'phialo-design/**'
-      - 'workers/**'
-      - '.github/workflows/cloudflare-pr-preview.yml'
 
 jobs:
   deploy-preview:
@@ -26,22 +22,36 @@ jobs:
         with:
           lfs: true
       
+      - name: Check for relevant file changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            should_deploy:
+              - 'phialo-design/**'
+              - 'workers/**'
+              - '.github/workflows/cloudflare-pr-preview.yml'
+      
       - name: Setup Node.js
+        if: steps.changes.outputs.should_deploy == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
       
       - name: Install pnpm
+        if: steps.changes.outputs.should_deploy == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 9
       
       - name: Get pnpm store directory
+        if: steps.changes.outputs.should_deploy == 'true'
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       
       - name: Setup pnpm cache
+        if: steps.changes.outputs.should_deploy == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
@@ -50,14 +60,17 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       
       - name: Install dependencies
+        if: steps.changes.outputs.should_deploy == 'true'
         working-directory: ./phialo-design
         run: pnpm install --frozen-lockfile
       
       - name: Build Astro site
+        if: steps.changes.outputs.should_deploy == 'true'
         working-directory: ./phialo-design
         run: pnpm run build
         
       - name: Create temporary wrangler config
+        if: steps.changes.outputs.should_deploy == 'true'
         working-directory: ./workers
         run: |
           cat > wrangler-pr-${{ github.event.pull_request.number }}.toml << EOF
@@ -77,11 +90,13 @@ jobs:
           EOF
       
       - name: Install Wrangler
+        if: steps.changes.outputs.should_deploy == 'true'
         working-directory: ./workers
         run: npm install wrangler@4.22.0
       
       - name: Deploy to Cloudflare Workers
         id: deploy
+        if: steps.changes.outputs.should_deploy == 'true'
         working-directory: ./workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -97,19 +112,21 @@ jobs:
       
       - name: Extract deployment URL
         id: extract-url
+        if: steps.changes.outputs.should_deploy == 'true'
         working-directory: ./workers
         run: |
           # The deployment URL will be in the format: https://phialo-pr-<number>.meise.workers.dev
           PREVIEW_URL="https://phialo-pr-${{ github.event.pull_request.number }}.meise.workers.dev"
           echo "preview_url=$PREVIEW_URL" >> $GITHUB_OUTPUT
       
-      - name: Comment PR with preview URL
+      - name: Comment PR with preview status
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr_number = context.issue.number;
-            const preview_url = '${{ steps.extract-url.outputs.preview_url }}';
+            const preview_url = '${{ steps.extract-url.outputs.preview_url || "" }}';
+            const shouldDeploy = '${{ steps.changes.outputs.should_deploy }}' === 'true';
             
             // Create a unique identifier for this comment
             const identifier = '<!-- cloudflare-preview-deployment -->';
@@ -125,11 +142,19 @@ jobs:
               comment.body?.includes(identifier)
             );
             
-            const body = identifier + '\n' +
-              '## 🚀 Cloudflare Preview Deployment\n\n' +
-              'Your preview deployment is ready!\n\n' +
-              '🔗 **Preview URL**: ' + preview_url + '\n\n' +
-              'This deployment will be automatically updated when you push new commits to this PR.\n';
+            let body;
+            if (shouldDeploy && preview_url) {
+              body = identifier + '\n' +
+                '## 🚀 Cloudflare Preview Deployment\n\n' +
+                'Your preview deployment is ready!\n\n' +
+                '🔗 **Preview URL**: ' + preview_url + '\n\n' +
+                'This deployment will be automatically updated when you push new commits to this PR.\n';
+            } else {
+              body = identifier + '\n' +
+                '## ℹ️ Cloudflare Preview Deployment Skipped\n\n' +
+                'No code changes detected in `phialo-design/` or `workers/` that require a new preview deployment.\n\n' +
+                'If you wish to force a deployment, please update code files or add a code comment.\n';
+            }
             
             if (existingComment) {
               // Update existing comment
@@ -150,7 +175,7 @@ jobs:
             }
       
       - name: Clean up temporary config
-        if: always()
+        if: always() && steps.changes.outputs.should_deploy == 'true'
         working-directory: ./workers
         run: |
           rm -f wrangler-pr-${{ github.event.pull_request.number }}.toml


### PR DESCRIPTION
## Summary
- Enable PR preview workflow to run on ALL pull requests
- Add intelligent conditional deployment based on file changes
- Ensure every PR gets feedback about preview deployments

## Problem
Currently, the PR preview workflow only triggers for changes in:
- `phialo-design/**`
- `workers/**`
- `.github/workflows/cloudflare-pr-preview.yml`

This means documentation-only PRs (like #231) don't get any preview deployment feedback, leaving contributors wondering if something is broken.

## Solution
Based on best practices research and Gemini Pro consultation, this PR:

1. **Removes the `paths` filter** - workflow now triggers on all PRs
2. **Adds `dorny/paths-filter`** - intelligently detects if deployment is needed
3. **Conditional execution** - only builds/deploys when code changes are detected
4. **Always provides feedback** - posts a comment explaining the deployment status

## How it Works
- **Code changes detected**: Full build and deployment with preview URL
- **Documentation-only changes**: Skip deployment but post informative comment
- **Resource optimization**: No unnecessary builds for non-code changes

## Example Comments

### When deployment happens:
> ## 🚀 Cloudflare Preview Deployment
> 
> Your preview deployment is ready\!
> 
> 🔗 **Preview URL**: https://phialo-pr-123.meise.workers.dev
> 
> This deployment will be automatically updated when you push new commits to this PR.

### When deployment is skipped:
> ## ℹ️ Cloudflare Preview Deployment Skipped
> 
> No code changes detected in `phialo-design/` or `workers/` that require a new preview deployment.
> 
> If you wish to force a deployment, please update code files or add a code comment.

## ⚠️ Important Note About Testing
**This PR's workflow changes won't run on this PR itself** because GitHub Actions uses workflow definitions from the default branch (master) for `pull_request` events. This is a security feature to prevent malicious PRs from running arbitrary workflows.

The changes will only take effect after merging to master. Future PRs will then benefit from these improvements.

## Testing
Once merged, the next documentation-only PR will demonstrate the new skip message functionality.

## Benefits
- ✅ Better developer experience - always know deployment status
- ✅ Resource efficiency - only build when necessary
- ✅ Clear communication - informative messages for all scenarios
- ✅ Maintains existing functionality - no breaking changes