### PR TITLE
Fix #255: Portfolio grid dynamic sizing issue

### DIFF
--- a/phialo-design/src/styles/global.css
+++ b/phialo-design/src/styles/global.css
@@ -231,7 +231,19 @@
   /* Portfolio grid styles */
   .portfolio-grid {
     @apply grid gap-8;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
+  }
+  
+  @media (max-width: 1024px) {
+    .portfolio-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  
+  @media (max-width: 640px) {
+    .portfolio-grid {
+      grid-template-columns: 1fr;
+    }
   }
 
   .portfolio-masonry {
@@ -427,8 +439,20 @@ select {
 /* Grid utilities */
 .grid-auto-fit {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--space-xl);
+}
+
+@media (max-width: 1024px) {
+  .grid-auto-fit {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .grid-auto-fit {
+    grid-template-columns: 1fr;
+  }
 }
 
 .grid-auto-fill {


### PR DESCRIPTION
## Summary
- Fixed the portfolio grid CSS to use fixed column counts instead of auto-fit
- Portfolio items now maintain consistent sizes when filtered
- Added responsive breakpoints for mobile, tablet, and desktop views

## Problem
When filtering portfolio items, the remaining items would expand to fill the available space due to the auto-fit CSS property. This caused a jarring visual effect where:
- 1 item = full width
- 2 items = 50% width each
- 3+ items = proper grid layout

## Solution
Replaced grid-template-columns with fixed column counts:
- Desktop: 3 columns
- Tablet (<=1024px): 2 columns  
- Mobile (<=640px): 1 column

Applied the fix to both:
- .portfolio-grid class
- .grid-auto-fit utility class

## Related Issues
Fixes #255

## Testing
- [x] Tested portfolio filtering with various item counts
- [x] Verified responsive behavior on different screen sizes
- [x] Ensured grid items maintain consistent sizing