### PR TITLE
fix: handle Dependabot PRs in CI workflows

### DIFF
--- a/.github/workflows/cloudflare-pr-cleanup.yml
+++ b/.github/workflows/cloudflare-pr-cleanup.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Delete PR preview worker
+        if: github.actor != 'dependabot[bot]'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -30,13 +31,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr_number = context.issue.number;
+            const isDependabot = '${{ github.actor }}' === 'dependabot[bot]';
             
             // Create a unique identifier for this comment
             const identifier = '<!-- cloudflare-preview-cleanup -->';
             
-            const body = identifier + '\n' +
-              '## 🧹 Preview Deployment Cleaned Up\n\n' +
-              'The Cloudflare preview deployment for this PR has been removed.\n';
+            let body;
+            if (isDependabot) {
+              // Skip comment for Dependabot PRs since they don't have deployments
+              return;
+            } else {
+              body = identifier + '\n' +
+                '## 🧹 Preview Deployment Cleaned Up\n\n' +
+                'The Cloudflare preview deployment for this PR has been removed.\n';
+            }
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -33,25 +33,25 @@ jobs:
               - '.github/workflows/cloudflare-pr-preview.yml'
       
       - name: Setup Node.js
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
       
       - name: Install pnpm
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         uses: pnpm/action-setup@v4
         with:
           version: 9
       
       - name: Get pnpm store directory
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
       
       - name: Setup pnpm cache
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
@@ -60,17 +60,17 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       
       - name: Install dependencies
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./phialo-design
         run: pnpm install --frozen-lockfile
       
       - name: Build Astro site
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./phialo-design
         run: pnpm run build
         
       - name: Create temporary wrangler config
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./workers
         run: |
           cat > wrangler-pr-${{ github.event.pull_request.number }}.toml << EOF
@@ -90,13 +90,13 @@ jobs:
           EOF
       
       - name: Install Wrangler
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./workers
         run: npm install wrangler@4.22.0
       
       - name: Deploy to Cloudflare Workers
         id: deploy
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -112,7 +112,7 @@ jobs:
       
       - name: Extract deployment URL
         id: extract-url
-        if: steps.changes.outputs.should_deploy == 'true'
+        if: steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./workers
         run: |
           # The deployment URL will be in the format: https://phialo-pr-<number>.meise.workers.dev
@@ -127,6 +127,7 @@ jobs:
             const pr_number = context.issue.number;
             const preview_url = '${{ steps.extract-url.outputs.preview_url }}' || '';
             const shouldDeploy = '${{ steps.changes.outputs.should_deploy }}' === 'true';
+            const isDependabot = '${{ github.actor }}' === 'dependabot[bot]';
             
             // Create a unique identifier for this comment
             const identifier = '<!-- cloudflare-preview-deployment -->';
@@ -143,7 +144,12 @@ jobs:
             );
             
             let body;
-            if (shouldDeploy && preview_url) {
+            if (isDependabot) {
+              body = identifier + '\n' +
+                '## 🤖 Cloudflare Preview Deployment Skipped\n\n' +
+                'Preview deployments are not available for Dependabot PRs due to security restrictions.\n\n' +
+                'Once this PR is reviewed and merged, the changes will be deployed automatically.\n';
+            } else if (shouldDeploy && preview_url) {
               body = identifier + '\n' +
                 '## 🚀 Cloudflare Preview Deployment\n\n' +
                 'Your preview deployment is ready!\n\n' +
@@ -175,7 +181,7 @@ jobs:
             }
       
       - name: Clean up temporary config
-        if: always() && steps.changes.outputs.should_deploy == 'true'
+        if: always() && steps.changes.outputs.should_deploy == 'true' && github.actor != 'dependabot[bot]'
         working-directory: ./workers
         run: |
           rm -f wrangler-pr-${{ github.event.pull_request.number }}.toml

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -50,14 +50,3 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      
-      - name: Add auto-merge label
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
-           steps.metadata.outputs.dependency-type == 'direct:development')
-        run: |
-          gh pr edit "$PR_URL" --add-label "auto-merge"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Fixed CI failures for all Dependabot PRs by addressing two common issues
- Dependabot PRs can now pass CI checks successfully

## Changes Made

### 1. Skip Cloudflare deployments for Dependabot PRs
- Added `github.actor \!= 'dependabot[bot]'` conditions to all Cloudflare deployment steps
- Dependabot PRs cannot access repository secrets for security reasons
- Added informative comment for Dependabot PRs explaining why deployments are skipped
- Updated cleanup workflow to skip worker deletion for non-existent deployments

### 2. Remove auto-merge label step
- Removed the "Add auto-merge label" step from dependabot workflow
- The label doesn't exist in the repository and was causing failures
- The workflow already uses GitHub's native auto-merge feature correctly

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Check that existing Dependabot PRs will pass CI after merge
- [ ] Confirm preview deployments still work for regular PRs

## Related Issues
Fixes CI failures for:
- #260 - chore(workers-dev)(deps-dev): bump @types/node
- #261 - chore(workers)(deps): bump itty-router
- #262 - chore(workers-dev)(deps-dev): bump cloudflare-dependencies
- #264 - chore(dev)(deps-dev): bump dev-dependencies group
- #265 - chore(deps): bump lucide-react
- #266 - chore(deps): bump production-dependencies group