### PR TITLE
Fix #276: Update DNA Spiral Earrings portfolio item

### DIFF
--- a/phialo-design/src/features/portfolio/data/portfolioDataDE.ts
+++ b/phialo-design/src/features/portfolio/data/portfolioDataDE.ts
@@ -9,12 +9,11 @@ export const portfolioItemsDE: PortfolioItemData[] = [
     slug: "dna-spirale-ohrhaenger",
     description: "Elegante Ohrhänger inspiriert von der DNA-Doppelhelix-Struktur. Diese einzigartigen Schmuckstücke verbinden wissenschaftliche Ästhetik mit kunstvoller Handwerkskunst.",
     year: 2023,
-    materials: ["925er Silber", "Rhodiniert"],
+    materials: ["Platin", "Fancy Diamanten"],
     techniques: ["3D-Modellierung", "Wachsausschmelzverfahren", "Handpolitur"],
     details: "Die spiralförmige Struktur wurde in Blender entworfen und durch präzise 3D-Drucktechnologie in Wachs umgesetzt. Nach dem Guss in 925er Silber wurden die Ohrhänger sorgfältig von Hand poliert und rhodiniert für dauerhaften Glanz.",
     gallery: [
-      "/images/portfolio/dna_spirale_freigestellt_refl.jpg",
-      "/images/portfolio/ohrhaenger_energetic_freigestellt_refl.jpg"
+      "/images/portfolio/dna_spirale_freigestellt_refl.jpg"
     ]
   },
   {

--- a/phialo-design/src/features/portfolio/data/portfolioDataEN.ts
+++ b/phialo-design/src/features/portfolio/data/portfolioDataEN.ts
@@ -9,12 +9,11 @@ export const portfolioItemsEN: PortfolioItemData[] = [
     slug: "dna-spirale-ohrhaenger",
     description: "Elegant earrings inspired by the DNA double helix structure. These unique pieces of jewelry combine scientific aesthetics with artistic craftsmanship.",
     year: 2023,
-    materials: ["925 Silver", "Rhodium-plated"],
+    materials: ["Platinum", "Fancy diamonds"],
     techniques: ["3D Modeling", "Lost-wax Casting", "Hand Polishing"],
     details: "The spiral structure was designed in Blender and realized through precise 3D printing technology in wax. After casting in 925 silver, the earrings were carefully hand-polished and rhodium-plated for lasting brilliance.",
     gallery: [
-      "/images/portfolio/dna_spirale_freigestellt_refl.jpg",
-      "/images/portfolio/ohrhaenger_energetic_freigestellt_refl.jpg"
+      "/images/portfolio/dna_spirale_freigestellt_refl.jpg"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Removed the specified image (`ohrhaenger_energetic_freigestellt_refl.jpg`) from the DNA Spiral Earrings gallery
- Updated materials from "925er Silber"/"Rhodiniert" to "Platin"/"Fancy Diamanten" as requested
- Applied changes to both German and English portfolio data files

## Changes Made
1. **Removed image from gallery**: The image `ohrhaenger_energetic_freigestellt_refl.jpg` has been removed from the gallery array in both language versions
2. **Updated materials**: Changed materials to match the requested specification:
   - German: "Platin", "Fancy Diamanten"
   - English: "Platinum", "Fancy diamonds"

## Testing
- ✅ Built the project successfully
- ✅ Tested locally on preview server (port 4322)
- ✅ Verified the modal displays correct materials in German version
- ✅ Verified the modal displays correct materials in English version
- ✅ Confirmed only one image remains in the gallery
- ✅ Ran lint and typecheck (no new issues introduced by these changes)

## Screenshots
The changes have been verified in the browser:
- Materials now show "Platin" and "Fancy Diamanten" (German)
- Materials now show "Platinum" and "Fancy diamonds" (English)
- Gallery only contains the main image

Fixes #276