### PR TITLE
fix: add 'founder of Phialo' to About page greeting #273

### DIFF
--- a/phialo-design/src/features/about/pages/en/index.astro
+++ b/phialo-design/src/features/about/pages/en/index.astro
@@ -19,7 +19,7 @@ import AnimatedText from '../../../../shared/components/ui/AnimatedText.tsx';
         <!-- Text content on the left -->
         <div class="space-y-6 px-5 md:px-0">
           <p class="text-lg leading-relaxed text-gray-700">
-            Hello! I am Gesa Pickbrenner.
+            Hello! I am Gesa Pickbrenner, founder of Phialo.
           </p>
 
           <p class="text-lg leading-relaxed text-gray-700">

--- a/phialo-design/src/features/about/pages/index.astro
+++ b/phialo-design/src/features/about/pages/index.astro
@@ -19,7 +19,7 @@ import AnimatedText from '../../../shared/components/ui/AnimatedText.tsx';
         <!-- Text content on the left -->
         <div class="space-y-6 px-5 md:px-0">
           <p class="text-lg leading-relaxed text-gray-700">
-            Hallo! Ich bin Gesa Pickbrenner.
+            Hallo! Ich bin Gesa Pickbrenner, Gründerin von Phialo.
           </p>
 
           <p class="text-lg leading-relaxed text-gray-700">


### PR DESCRIPTION
## Summary
This PR addresses issue #273 by updating the greeting text on the About page to include "founder of Phialo" in both German and English versions.

## Changes Made
- Updated German greeting from "Hallo\! Ich bin Gesa Pickbrenner." to "Hallo\! Ich bin Gesa Pickbrenner, Gründerin von Phialo."
- Updated English greeting from "Hello\! I am Gesa Pickbrenner." to "Hello\! I am Gesa Pickbrenner, founder of Phialo."

## Files Modified
- `src/features/about/pages/index.astro` - German version
- `src/features/about/pages/en/index.astro` - English version

## Testing
- ✅ Tested locally on both German (/) and English (/en) versions
- ✅ Verified text displays correctly in browser
- ✅ No hydration errors or console warnings
- ✅ Linting and type checking completed (no new errors introduced)

## Screenshots
### German Version
Text shows: "Hallo\! Ich bin Gesa Pickbrenner, Gründerin von Phialo."

### English Version  
Text shows: "Hello\! I am Gesa Pickbrenner, founder of Phialo."

Closes #273