### PR TITLE
fix: change About Me page title to About (issue #272)

### DIFF
--- a/phialo-design/src/features/about/pages/en/index.astro
+++ b/phialo-design/src/features/about/pages/en/index.astro
@@ -3,14 +3,14 @@ import PageLayout from '../../../../shared/layouts/PageLayout.astro';
 import AnimatedText from '../../../../shared/components/ui/AnimatedText.tsx';
 ---
 
-<PageLayout title="About Me - Gesa Pickbrenner | Phialo Design" description="Learn about Gesa Pickbrenner - from traditional goldsmithing to 3D design and education.">
+<PageLayout title="About - Gesa Pickbrenner | Phialo Design" description="Learn about Gesa Pickbrenner - from traditional goldsmithing to 3D design and education.">
   <section class="py-24 bg-white">
     <div class="container mx-auto px-6 md:px-8 max-w-6xl">
       <!-- Title -->
       <div class="text-center mb-16">
         <AnimatedText client:visible>
           <h1 class="font-display text-4xl md:text-5xl font-medium text-midnight mb-6">
-            About Me
+            About
           </h1>
         </AnimatedText>
       </div>

--- a/phialo-design/src/shared/hooks/useLanguage.ts
+++ b/phialo-design/src/shared/hooks/useLanguage.ts
@@ -45,7 +45,7 @@ const commonTranslations: Translations = {
   'nav.portfolio': { en: 'Portfolio', de: 'Portfolio' },
   'nav.services': { en: '3D for You', de: '3D für Sie' },
   'nav.tutorials': { en: 'Tutorials', de: 'Tutorials' },
-  'nav.about': { en: 'About Me', de: 'Über mich' },
+  'nav.about': { en: 'About', de: 'Über mich' },
   'nav.contact': { en: 'Contact', de: 'Kontakt' },
   
   // Common UI elements

--- a/phialo-design/src/shared/navigation/Navigation.tsx
+++ b/phialo-design/src/shared/navigation/Navigation.tsx
@@ -8,7 +8,7 @@ const navItems = [
   { href: '/portfolio', label: 'Portfolio' },
   { href: '/services', label: '3D für Sie', labelEn: '3D for You' },
   { href: '/classes', label: 'Classes' },
-  { href: '/about', label: 'Über mich', labelEn: 'About Me' },
+  { href: '/about', label: 'Über mich', labelEn: 'About' },
   { href: '/contact', label: 'Kontakt', labelEn: 'Contact' }
 ];
 

--- a/phialo-design/src/test/components/layout/MobileMenu.test.tsx
+++ b/phialo-design/src/test/components/layout/MobileMenu.test.tsx
@@ -8,7 +8,7 @@ describe('MobileMenu', () => {
     { href: '/portfolio', label: 'Portfolio' },
     { href: '/services', label: '3D für Sie', labelEn: '3D for You' },
     { href: '/classes', label: 'Classes' },
-    { href: '/about', label: 'Über mich', labelEn: 'About Me' },
+    { href: '/about', label: 'Über mich', labelEn: 'About' },
     { href: '/contact', label: 'Kontakt', labelEn: 'Contact' }
   ];
 

--- a/phialo-design/src/test/components/layout/Navigation.test.tsx
+++ b/phialo-design/src/test/components/layout/Navigation.test.tsx
@@ -77,7 +77,7 @@ describe('Navigation', () => {
       expect(screen.getByText('Portfolio')).toBeInTheDocument();
       expect(screen.getByText('3D for You')).toBeInTheDocument();
       expect(screen.getByText('Classes')).toBeInTheDocument();
-      expect(screen.getByText('About Me')).toBeInTheDocument();
+      expect(screen.getByText('About')).toBeInTheDocument();
       expect(screen.getByText('Contact')).toBeInTheDocument();
     });
 
@@ -87,7 +87,7 @@ describe('Navigation', () => {
       const portfolioLink = screen.getByRole('link', { name: 'Portfolio' });
       const servicesLink = screen.getByRole('link', { name: '3D for You' });
       const classesLink = screen.getByRole('link', { name: 'Classes' });
-      const aboutLink = screen.getByRole('link', { name: 'About Me' });
+      const aboutLink = screen.getByRole('link', { name: 'About' });
       const contactLink = screen.getByRole('link', { name: 'Contact' });
 
       expect(portfolioLink).toHaveAttribute('href', '/en/portfolio');

--- a/phialo-design/src/test/pages/AboutMe.test.tsx
+++ b/phialo-design/src/test/pages/AboutMe.test.tsx
@@ -7,7 +7,7 @@ vi.mock('../../components/common/AnimatedText', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
 }));
 
-describe('About Me Page', () => {
+describe('About Page', () => {
   it('should display German content correctly', () => {
     const germanContent = {
       title: 'Über mich',
@@ -56,7 +56,7 @@ describe('About Me Page', () => {
 
   it('should display English content correctly', () => {
     const englishContent = {
-      title: 'About Me',
+      title: 'About',
       greeting: "Hi! I'm Gesa Pickbrenner.",
       intro: 'From a young age, I was mesmerized with anything artistic. Drawing, painting and sculpting have always been my way of expression.',
       goldsmithing: '2015 I graduated in the traditional art of goldsmithing as the best graduate in the whole of Northern Germany.',
@@ -104,7 +104,7 @@ describe('About Me Page', () => {
     const AboutMePage = () => (
       <main className="pt-32 pb-16">
         <div className="container mx-auto px-4 max-w-6xl">
-          <h1>About Me</h1>
+          <h1>About</h1>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-start">
             <div className="space-y-6">
               <p>Text content</p>


### PR DESCRIPTION
## Summary
- Changed the English About page title from "About Me" to "About"
- Updated navigation links, translations, and test files accordingly
- Maintained German version as "Über mich" (unchanged)

## Changes made
1. Updated page title in `/src/features/about/pages/en/index.astro`
2. Updated h1 heading in the same file
3. Updated navigation label in `/src/shared/navigation/Navigation.tsx`
4. Updated translation in `/src/shared/hooks/useLanguage.ts`
5. Updated test expectations in multiple test files

## Test plan
- [x] Verified English About page shows "About" as title and heading
- [x] Verified German About page still shows "Über mich"
- [x] Verified navigation shows correct labels in both languages
- [x] Ran lint and typecheck (existing errors unrelated to changes)
- [x] Updated relevant test files

Fixes #272