### PR TITLE
feat: Add image to Guss & 3D-Druck service card (#292)

### DIFF
--- a/phialo-design/public/images/3DfuerSie/3d-printing-casting-service.jpg
+++ b/phialo-design/public/images/3DfuerSie/3d-printing-casting-service.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5605a3bafea64f512f85c3c5e98ca6afdd442a540de46ed22b3e14bc4d13f8f0
+size 618863

--- a/phialo-design/src/features/services/components/ServicesSection.astro
+++ b/phialo-design/src/features/services/components/ServicesSection.astro
@@ -145,6 +145,9 @@ const t = isEnglish ? content.en : content.de;
         <p class="text-sm font-medium text-midnight mb-4 text-center">
           <strong>{isEnglish ? 'Your Benefits:' : 'Ihre Vorteile:'}</strong> {t.service2.advantages.replace(/^.*?: /, '')}
         </p>
+        <div class="flex justify-center mb-6">
+          <img src="/images/3DfuerSie/3d-printing-casting-service.jpg" alt={isEnglish ? "3D Printing and Casting Service" : "3D-Druck- und Gussservice"} class="rounded-lg shadow-md w-full max-w-xs md:max-w-full" />
+        </div>
         <div class="service-cta">
           <Button href={t.contactUrl} variant="primary" size="sm">
             {t.service2.cta}


### PR DESCRIPTION
## Summary
- Added the requested image to the "Guss & 3D-Druck" service card on the 3D für Sie page
- Implemented bilingual support with appropriate alt text for both German and English versions
- Maintained visual consistency with other service cards

## Changes Made
1. **Downloaded Image**: Saved the image from GitHub issue #292 to `/phialo-design/public/images/3DfuerSie/3d-printing-casting-service.jpg`
2. **Updated ServicesSection Component**: Added image display in the featured service card with responsive styling
3. **Bilingual Alt Text**: Implemented language-aware alt text ("3D-Druck- und Gussservice" for German, "3D Printing and Casting Service" for English)

## Testing
- ✅ Verified image displays correctly on German version (`/services`)
- ✅ Verified image displays correctly on English version (`/en/services`)
- ✅ Tested responsive behavior - image scales appropriately on different screen sizes
- ✅ Consistent styling with other service cards (rounded corners, shadow, responsive width)
- ✅ No console errors or warnings
- ✅ Linting and type checking completed (no new issues introduced)

## Visual Proof
The image now appears in the featured "Guss & 3D-Druck" service card, matching the styling of the other two service cards that already had images.

## Related Issue
Closes #292

## Pre-merge Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of the code completed
- [x] Changes tested locally
- [x] No console errors or warnings
- [x] Responsive design tested
- [x] Both language versions tested