### PR TITLE
Fix: Deployment workflows not setting Cloudflare Worker secrets

### DIFF
--- a/.github/workflows/deploy-command.yml
+++ b/.github/workflows/deploy-command.yml
@@ -142,26 +142,36 @@ jobs:
           PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.PUBLIC_TURNSTILE_SITE_KEY }}
         run: pnpm run build
       
+      - name: Install Wrangler
+        working-directory: ./workers
+        run: pnpm install wrangler@4.22.0
+      
       - name: Deploy to Cloudflare Workers
         id: deploy
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: 'workers'
-          command: |
-            deploy --env ${{ needs.check-command.outputs.environment }} \
-            ${{ needs.check-command.outputs.environment == 'preview' && format('--name phialo-pr-{0}', needs.check-command.outputs.pr_number) || '' }}
-          secrets: |
-            RESEND_API_KEY
-            FROM_EMAIL
-            TO_EMAIL
-            TURNSTILE_SECRET_KEY
+        working-directory: ./workers
         env:
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
-          TO_EMAIL: ${{ secrets.TO_EMAIL }}
-          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Deploy the worker
+          if [ "${{ needs.check-command.outputs.environment }}" = "preview" ]; then
+            npx wrangler deploy --env preview --name phialo-pr-${{ needs.check-command.outputs.pr_number }}
+            WORKER_NAME="phialo-pr-${{ needs.check-command.outputs.pr_number }}"
+          else
+            npx wrangler deploy --env production
+            WORKER_NAME="phialo"
+          fi
+          
+          # Set secrets for the deployed worker
+          echo "${{ secrets.RESEND_API_KEY }}" | npx wrangler secret put RESEND_API_KEY --name $WORKER_NAME
+          echo "${{ secrets.FROM_EMAIL }}" | npx wrangler secret put FROM_EMAIL --name $WORKER_NAME
+          echo "${{ secrets.TO_EMAIL }}" | npx wrangler secret put TO_EMAIL --name $WORKER_NAME
+          echo "${{ secrets.TURNSTILE_SECRET_KEY }}" | npx wrangler secret put TURNSTILE_SECRET_KEY --name $WORKER_NAME
+          
+          # Set optional REPLY_TO_EMAIL if it exists
+          if [ -n "${{ secrets.REPLY_TO_EMAIL }}" ]; then
+            echo "${{ secrets.REPLY_TO_EMAIL }}" | npx wrangler secret put REPLY_TO_EMAIL --name $WORKER_NAME
+          fi
       
       - name: Get deployment URL
         id: url

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -97,6 +97,11 @@ jobs:
           echo "${{ secrets.FROM_EMAIL }}" | npx wrangler secret put FROM_EMAIL --name phialo-master
           echo "${{ secrets.TO_EMAIL }}" | npx wrangler secret put TO_EMAIL --name phialo-master
           echo "${{ secrets.TURNSTILE_SECRET_KEY }}" | npx wrangler secret put TURNSTILE_SECRET_KEY --name phialo-master
+          
+          # Set optional REPLY_TO_EMAIL if it exists
+          if [ -n "${{ secrets.REPLY_TO_EMAIL }}" ]; then
+            echo "${{ secrets.REPLY_TO_EMAIL }}" | npx wrangler secret put REPLY_TO_EMAIL --name phialo-master
+          fi
       
       - name: Clean up temporary config
         if: always()

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -152,24 +152,37 @@ jobs:
           DEBUG: ${{ github.event.inputs.debug }}
           PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.PUBLIC_TURNSTILE_SITE_KEY }}
       
+      - name: Install Wrangler
+        working-directory: ./workers
+        run: pnpm install wrangler@4.22.0
+      
       - name: Deploy to Cloudflare Workers
         id: deploy
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: 'workers'
-          command: deploy --env ${{ github.event.inputs.environment }}
-          secrets: |
-            RESEND_API_KEY
-            FROM_EMAIL
-            TO_EMAIL
-            TURNSTILE_SECRET_KEY
+        working-directory: ./workers
         env:
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
-          TO_EMAIL: ${{ secrets.TO_EMAIL }}
-          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Deploy the worker
+          npx wrangler deploy --env ${{ github.event.inputs.environment }}
+          
+          # Determine the worker name based on environment
+          if [ "${{ github.event.inputs.environment }}" = "production" ]; then
+            WORKER_NAME="phialo"
+          else
+            WORKER_NAME="phialo-design-preview"
+          fi
+          
+          # Set secrets for the deployed worker
+          echo "${{ secrets.RESEND_API_KEY }}" | npx wrangler secret put RESEND_API_KEY --name $WORKER_NAME
+          echo "${{ secrets.FROM_EMAIL }}" | npx wrangler secret put FROM_EMAIL --name $WORKER_NAME
+          echo "${{ secrets.TO_EMAIL }}" | npx wrangler secret put TO_EMAIL --name $WORKER_NAME
+          echo "${{ secrets.TURNSTILE_SECRET_KEY }}" | npx wrangler secret put TURNSTILE_SECRET_KEY --name $WORKER_NAME
+          
+          # Set optional REPLY_TO_EMAIL if it exists
+          if [ -n "${{ secrets.REPLY_TO_EMAIL }}" ]; then
+            echo "${{ secrets.REPLY_TO_EMAIL }}" | npx wrangler secret put REPLY_TO_EMAIL --name $WORKER_NAME
+          fi
       
       - name: Get deployment URL
         id: url

--- a/.github/workflows/webhook-deploy.yml
+++ b/.github/workflows/webhook-deploy.yml
@@ -85,23 +85,36 @@ jobs:
           PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.PUBLIC_TURNSTILE_SITE_KEY }}
         run: pnpm run build
       
+      - name: Install Wrangler
+        working-directory: ./workers
+        run: pnpm install wrangler@4.22.0
+      
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: 'workers'
-          command: deploy --env ${{ needs.validate-webhook.outputs.environment }}
-          secrets: |
-            RESEND_API_KEY
-            FROM_EMAIL
-            TO_EMAIL
-            TURNSTILE_SECRET_KEY
+        working-directory: ./workers
         env:
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
-          TO_EMAIL: ${{ secrets.TO_EMAIL }}
-          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Deploy the worker
+          npx wrangler deploy --env ${{ needs.validate-webhook.outputs.environment }}
+          
+          # Determine the worker name based on environment
+          if [ "${{ needs.validate-webhook.outputs.environment }}" = "production" ]; then
+            WORKER_NAME="phialo"
+          else
+            WORKER_NAME="phialo-design-preview"
+          fi
+          
+          # Set secrets for the deployed worker
+          echo "${{ secrets.RESEND_API_KEY }}" | npx wrangler secret put RESEND_API_KEY --name $WORKER_NAME
+          echo "${{ secrets.FROM_EMAIL }}" | npx wrangler secret put FROM_EMAIL --name $WORKER_NAME
+          echo "${{ secrets.TO_EMAIL }}" | npx wrangler secret put TO_EMAIL --name $WORKER_NAME
+          echo "${{ secrets.TURNSTILE_SECRET_KEY }}" | npx wrangler secret put TURNSTILE_SECRET_KEY --name $WORKER_NAME
+          
+          # Set optional REPLY_TO_EMAIL if it exists
+          if [ -n "${{ secrets.REPLY_TO_EMAIL }}" ]; then
+            echo "${{ secrets.REPLY_TO_EMAIL }}" | npx wrangler secret put REPLY_TO_EMAIL --name $WORKER_NAME
+          fi
       
       - name: Send webhook response
         if: github.event.client_payload.callback_url


### PR DESCRIPTION
## Summary
- Fixes production contact form failing due to missing environment variables
- Replaces incorrect wrangler-action secrets parameter with proper `wrangler secret put` commands
- Ensures all deployment workflows consistently set Worker secrets

## Problem
The production deployment at phialo.de was failing with "Email service is not configured properly" errors because the GitHub environment secrets weren't being properly passed to Cloudflare Workers. 

The workflows were using the `secrets` parameter in `cloudflare/wrangler-action@v3`, which only passes secrets as environment variables during build time but doesn't actually set them as persistent Worker secrets.

## Solution
Updated all deployment workflows to:
1. Deploy the Worker first
2. Then explicitly set secrets using `wrangler secret put` commands
3. Include optional REPLY_TO_EMAIL secret support

## Changes
- ✅ `manual-deploy.yml` - Fixed to use wrangler secret put for all environments
- ✅ `deploy-command.yml` - Fixed PR deployment secret handling
- ✅ `webhook-deploy.yml` - Fixed webhook-triggered deployment secrets
- ✅ `deploy-master.yml` - Added optional REPLY_TO_EMAIL secret support

## Testing
After deployment with these changes:
1. Secrets will be properly set in Cloudflare Workers
2. Contact form will have access to RESEND_API_KEY, FROM_EMAIL, TO_EMAIL
3. Email functionality will work in production

## Error Logs Before Fix
```json
{
  "message": "[ERROR] Email service is not configured properly",
  "hasResendKey": "[REDACTED]",
  "hasToEmail": false,
  "hasFromEmail": false
}
```

This critical fix ensures environment secrets from GitHub are properly synchronized to Cloudflare Workers runtime.