### PR TITLE
feat: Add manual Cloudflare worker management workflows

### DIFF
--- a/.github/workflows/cloudflare-list-and-cleanup-workers.yml
+++ b/.github/workflows/cloudflare-list-and-cleanup-workers.yml
@@ -85,11 +85,19 @@ jobs:
           
           # Filter PR workers
           PR_WORKERS=$(echo "$ALL_WORKERS" | grep '^phialo-pr-[0-9]\+$' || true)
-          PR_COUNT=$(echo "$PR_WORKERS" | grep -c . || echo "0")
+          if [ -z "$PR_WORKERS" ] || [ "$PR_WORKERS" = "" ]; then
+            PR_COUNT=0
+          else
+            PR_COUNT=$(echo "$PR_WORKERS" | wc -l | tr -d ' ')
+          fi
           
           # Filter other workers
           OTHER_WORKERS=$(echo "$ALL_WORKERS" | grep -v '^phialo-pr-[0-9]\+$' || true)
-          OTHER_COUNT=$(echo "$OTHER_WORKERS" | grep -c . || echo "0")
+          if [ -z "$OTHER_WORKERS" ] || [ "$OTHER_WORKERS" = "" ]; then
+            OTHER_COUNT=0
+          else
+            OTHER_COUNT=$(echo "$OTHER_WORKERS" | wc -l | tr -d ' ')
+          fi
           
           echo "📊 Summary:"
           echo "  Total workers: $TOTAL_COUNT"
@@ -157,6 +165,7 @@ jobs:
           fi
           
           # Provide recommendations
+          ORPHANED_COUNT=0
           if [ "$PR_COUNT" -gt 0 ]; then
             ORPHANED_COUNT=$(for worker in $PR_WORKERS; do
               PR_NUM=${worker#phialo-pr-}


### PR DESCRIPTION
## Purpose
This PR adds manual GitHub Actions workflows for comprehensive Cloudflare worker management, fixing issues found after the initial cleanup PR was merged.

## Background
After PR #370 was merged, we discovered that manual cleanup was still needed for existing PR workers. The initial attempt to use these workflows revealed some issues with the bash script counting logic.

## Changes

### New Workflows Added
1. **`cloudflare-cleanup-all-pr-workers.yml`**
   - Bulk deletion of all PR workers
   - Safety confirmation (requires typing "DELETE ALL")
   - Dry run mode by default
   - Comprehensive reporting and issue creation on failure

2. **`cloudflare-list-and-cleanup-workers.yml`**
   - Multi-action workflow for worker management
   - List all workers with status (open/closed PRs)
   - Delete all PR workers
   - Delete specific worker by name
   - Shows creation dates and URLs

### Fixes Applied
- Fixed PR_COUNT and OTHER_COUNT calculation when no workers match
- Initialize ORPHANED_COUNT to prevent undefined variable errors  
- Use `wc -l` instead of `grep -c` to avoid exit code issues
- Improve empty string checks for better reliability

## Testing
The workflows have been tested and fixed for the counting issues that caused the initial failure.

## Usage
After merging, you can:
1. Go to Actions tab
2. Run "Cloudflare - List and Cleanup Workers" to see all workers
3. Run "Cloudflare - Delete All PR Workers" to bulk delete

This provides immediate manual control over Cloudflare workers for cleanup operations.