### PR TITLE
fix: Skip Cloudflare deployments for Dependabot PRs

### DIFF
--- a/.github/workflows/cloudflare-pr-preview-cached.yml
+++ b/.github/workflows/cloudflare-pr-preview-cached.yml
@@ -22,7 +22,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Check if we should deploy (skip for Dependabot PRs to avoid secret access issues)
+  check-deploy:
+    runs-on: ubuntu-latest
+    name: Check Deployment Eligibility
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+    permissions:
+      pull-requests: write
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "should-deploy=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Skipping deployment for Dependabot PR (secrets not available)"
+          else
+            echo "should-deploy=true" >> $GITHUB_OUTPUT
+            echo "✅ Deployment eligible"
+          fi
+      
+      - name: Comment on Dependabot PR
+        if: github.actor == 'dependabot[bot]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            
+            // Check if we already commented
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Dependabot PR - Deployment Skipped')
+            );
+            
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `### 🤖 Dependabot PR - Deployment Skipped\n\n⚠️ **Preview deployment is not available for Dependabot PRs** due to security restrictions.\n\nTo test these changes:\n1. Merge the PR if tests pass\n2. Or manually trigger deployment after review\n3. Or check out the branch locally to test\n\nAll other CI checks will run normally.`
+              });
+            }
+
   deploy-preview:
+    needs: check-deploy
+    if: needs.check-deploy.outputs.should-deploy == 'true'
     runs-on: ubuntu-latest
     name: Deploy PR Preview with Caching
     environment:

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -5,7 +5,56 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  # Check if we should deploy (skip for Dependabot PRs to avoid secret access issues)
+  check-deploy:
+    runs-on: ubuntu-latest
+    name: Check Deployment Eligibility
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+    permissions:
+      pull-requests: write
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "should-deploy=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Skipping deployment for Dependabot PR (secrets not available)"
+          else
+            echo "should-deploy=true" >> $GITHUB_OUTPUT
+            echo "✅ Deployment eligible"
+          fi
+      
+      - name: Comment on Dependabot PR
+        if: github.actor == 'dependabot[bot]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            
+            // Check if we already commented
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Dependabot PR - Deployment Skipped')
+            );
+            
+            if (!botComment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `### 🤖 Dependabot PR - Deployment Skipped\n\n⚠️ **Preview deployment is not available for Dependabot PRs** due to security restrictions.\n\nTo test these changes:\n1. Merge the PR if tests pass\n2. Or manually trigger deployment after review\n3. Or check out the branch locally to test\n\nAll other CI checks will run normally.`
+              });
+            }
+
   deploy-preview:
+    needs: check-deploy
+    if: needs.check-deploy.outputs.should-deploy == 'true'
     runs-on: ubuntu-latest
     name: Deploy PR Preview to Cloudflare Workers
     permissions:


### PR DESCRIPTION
## Problem
Dependabot PRs are failing because they don't have access to repository secrets (by design for security). This causes the 'Deploy PR Preview' workflows to fail with 'CLOUDFLARE_API_TOKEN is not set' errors.

## Solution
- Add a pre-check job that determines if deployment should proceed
- Skip deployment for Dependabot PRs to avoid secret access issues
- Add an informative comment on Dependabot PRs explaining why deployment is skipped
- All other CI checks continue to run normally

## Impact
- Dependabot PRs will no longer fail due to missing secrets
- Developers can still merge Dependabot PRs if all other tests pass
- The PR comment explains the limitation clearly

Fixes the issue where all Dependabot PRs were showing as failing due to deployment errors.